### PR TITLE
Allow macro_identifier everywhere an identifier is

### DIFF
--- a/codee/patches/0021-Allow-macro_identifier-everywhere-an-identifier-is.patch
+++ b/codee/patches/0021-Allow-macro_identifier-everywhere-an-identifier-is.patch
@@ -1,0 +1,4986 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Diego Alonso <diego.alonso@appentra.com>
+Date: Tue, 3 Mar 2026 10:55:54 +0100
+Subject: Allow macro_identifier everywhere an identifier is
+
+---
+ grammar.js                         | 134 ++++----
+ test/corpus/constructs.txt         | 438 ++++++++++++++++---------
+ test/corpus/cudafortran.txt        |  15 +-
+ test/corpus/expressions.txt        | 108 ++++---
+ test/corpus/floating.txt           |  48 ++-
+ test/corpus/line_continuations.txt |  54 ++--
+ test/corpus/preprocessor.txt       | 204 ++++++++----
+ test/corpus/regressions.txt        |  48 ++-
+ test/corpus/statements.txt         | 504 +++++++++++++++++++----------
+ 9 files changed, 1014 insertions(+), 539 deletions(-)
+
+diff --git a/grammar.js b/grammar.js
+index 08f7785..7fe70c6 100644
+--- a/grammar.js
++++ b/grammar.js
+@@ -198,7 +198,7 @@ module.exports = grammar({
+       preprocessor('include'),
+       field('path', choice(
+         $.string_literal,
+-        $.identifier,
++        $._identifier,
+         $.system_lib_string,
+         alias($.preproc_call_expression, $.call_expression),
+       )),
+@@ -207,7 +207,7 @@ module.exports = grammar({
+ 
+     preproc_def: $ => seq(
+       preprocessor('define'),
+-      field('name', $.identifier),
++      field('name', $._identifier),
+       // HACK: This `optional($.whitespace)` is a workaround to prevent
+       // `tree-sitter` from misinterpreting `#define FOO (bar * baz)` as a
+       // `preproc_function_def`. For reasons related to how `token.immediate()`
+@@ -224,14 +224,14 @@ module.exports = grammar({
+ 
+     preproc_function_def: $ => seq(
+       preprocessor('define'),
+-      field('name', $.identifier),
++      field('name', $._identifier),
+       field('parameters', $.preproc_params),
+       field('value', optional($.preproc_arg)),
+       $._external_end_of_statement,
+     ),
+ 
+     preproc_params: $ => seq(
+-      token.immediate('('), commaSep(choice($.identifier, '...')), ')',
++      token.immediate('('), commaSep(choice($._identifier, '...')), ')',
+     ),
+ 
+     preproc_call: $ => seq(
+@@ -270,7 +270,7 @@ module.exports = grammar({
+     preproc_directive: _ => /#[ \t]*[a-zA-Z0-9]\w*/,
+ 
+     _preproc_expression: $ => choice(
+-      $.identifier,
++      $._identifier,
+       alias($.preproc_call_expression, $.call_expression),
+       $.number_literal,
+       $.string_literal,
+@@ -287,8 +287,8 @@ module.exports = grammar({
+     ),
+ 
+     preproc_defined: $ => choice(
+-      prec(PREPROC_PREC.CALL, seq('defined', '(', $.identifier, ')')),
+-      seq('defined', $.identifier),
++      prec(PREPROC_PREC.CALL, seq('defined', '(', $._identifier, ')')),
++      seq('defined', $._identifier),
+     ),
+ 
+     // Preprocessor unary operator uses an external scanner to catch
+@@ -299,7 +299,7 @@ module.exports = grammar({
+     )),
+ 
+     preproc_call_expression: $ => prec(PREPROC_PREC.CALL, seq(
+-      field('function', $.identifier),
++      field('function', $._identifier),
+       field('arguments', alias($.preproc_argument_list, $.argument_list)),
+     )),
+ 
+@@ -556,7 +556,7 @@ module.exports = grammar({
+     language_binding: $ => seq(
+       caseInsensitive('bind'),
+       '(',
+-      $.identifier,
++      $._identifier,
+       optional(seq(',', $.keyword_argument)),
+       ')'
+     ),
+@@ -585,11 +585,11 @@ module.exports = grammar({
+     function_result: $ => seq(
+       caseInsensitive('result'),
+       '(',
+-      $.identifier,
++      $._identifier,
+       ')'
+     ),
+ 
+-    _name: $ => alias($.identifier, $.name),
++    _name: $ => alias($._identifier, $.name),
+ 
+     _parameters: $ => choice(
+       seq('(', ')'),
+@@ -598,7 +598,7 @@ module.exports = grammar({
+ 
+     parameters: $ => seq(
+       '(',
+-      commaSep1($.identifier),
++      commaSep1($._identifier),
+       ')'
+     ),
+ 
+@@ -693,15 +693,15 @@ module.exports = grammar({
+       optional(commaSep1(
+         choice(
+           $.use_alias,
+-          $.identifier,
++          $._identifier,
+           $._generic_procedure)
+       ))
+     ),
+ 
+     use_alias: $ => seq(
+-      alias($.identifier, $.local_name),
++      alias($._identifier, $.local_name),
+       '=>',
+-      $.identifier
++      $._identifier
+     ),
+ 
+     implicit_statement: $ => seq(
+@@ -743,8 +743,8 @@ module.exports = grammar({
+     _identifier_or_common_block: $ => seq(
+       optional('::'),
+       commaSep1(choice(
+-        $.identifier,
+-        seq('/', alias($.identifier, $.common_block), '/'),
++        $._identifier,
++        seq('/', alias($._identifier, $.common_block), '/'),
+       )),
+     ),
+ 
+@@ -752,7 +752,7 @@ module.exports = grammar({
+       caseInsensitive('private'),
+       optional(seq(
+         optional('::'),
+-        commaSep1(choice($.identifier, $._generic_procedure))
++        commaSep1(choice($._identifier, $._generic_procedure))
+       )),
+     )),
+ 
+@@ -760,7 +760,7 @@ module.exports = grammar({
+       caseInsensitive('public'),
+       optional(seq(
+         optional('::'),
+-        commaSep1(choice($.identifier, $._generic_procedure))
++        commaSep1(choice($._identifier, $._generic_procedure))
+       )),
+     )),
+ 
+@@ -795,10 +795,10 @@ module.exports = grammar({
+       optional($._import_names),
+     )),
+     _import_names: $ => choice(
+-      seq(optional('::'), commaSep1($.identifier)),
++      seq(optional('::'), commaSep1($._identifier)),
+       seq(',',
+           choice(
+-            seq(caseInsensitive('only'), ':', commaSep1($.identifier)),
++            seq(caseInsensitive('only'), ':', commaSep1($._identifier)),
+             caseInsensitive('none'),
+             caseInsensitive('all')
+           )
+@@ -838,7 +838,7 @@ module.exports = grammar({
+ 
+     base_type_specifier: $ => seq(
+       caseInsensitive('extends'),
+-      '(', $.identifier, ')'
++      '(', $._identifier, ')'
+     ),
+ 
+     // These are only valid to specify once each, but tree-sitter
+@@ -868,7 +868,7 @@ module.exports = grammar({
+ 
+     end_type_statement: $ => blockStructureEnding($, 'type'),
+ 
+-    _type_name: $ => alias($.identifier, $.type_name),
++    _type_name: $ => alias($._identifier, $.type_name),
+ 
+     derived_type_procedures: $ => seq(
+       $.contains_statement,
+@@ -885,7 +885,7 @@ module.exports = grammar({
+     procedure_statement: $ => seq(
+       $.procedure_kind,
+       optional(seq(
+-        '(', alias($.identifier, $.procedure_interface), ')'
++        '(', alias($._identifier, $.procedure_interface), ')'
+       )),
+       optional(seq(
+         ',',
+@@ -899,7 +899,7 @@ module.exports = grammar({
+     ),
+     binding: $ => seq($.binding_name, '=>', $.method_name),
+     binding_name: $ => choice(
+-      $.identifier,
++      $._identifier,
+       $._generic_procedure
+     ),
+     method_name: $ => $._name,
+@@ -917,7 +917,7 @@ module.exports = grammar({
+       caseInsensitive('deferred'),
+       seq(
+         caseInsensitive('pass'),
+-        optional(seq('(', $.identifier, ')'))
++        optional(seq('(', $._identifier, ')'))
+       ),
+       caseInsensitive('nopass'),
+       caseInsensitive('non_overridable'),
+@@ -955,7 +955,7 @@ module.exports = grammar({
+         '(',
+         optional(
+           choice(
+-            alias($.identifier, $.procedure_interface),
++            alias($._identifier, $.procedure_interface),
+             $.intrinsic_type,
+             $.derived_type,
+           )
+@@ -988,13 +988,13 @@ module.exports = grammar({
+     ),
+ 
+     _variable_declarator: $ => choice(
+-      $.identifier,
++      $._identifier,
+       $.sized_declarator,
+       $.coarray_declarator,
+     ),
+ 
+     sized_declarator: $ => prec.right(1, seq(
+-        $.identifier,
++        $._identifier,
+         choice(
+           seq(
+             alias($.argument_list, $.size),
+@@ -1066,7 +1066,7 @@ module.exports = grammar({
+       ),
+       '(',
+       field('name', choice(
+-        $.identifier,
++        $._identifier,
+         $.derived_type_member_expression,
+       )),
+       ')'
+@@ -1161,7 +1161,7 @@ module.exports = grammar({
+       ')',
+     )),
+ 
+-    parameter_assignment: $ => seq($.identifier, '=', $._expression),
++    parameter_assignment: $ => seq($._identifier, '=', $._expression),
+ 
+     equivalence_statement: $ => seq(
+       caseInsensitive('equivalence'),
+@@ -1170,9 +1170,9 @@ module.exports = grammar({
+ 
+     equivalence_set: $ => seq(
+       '(',
+-      choice($.identifier, $.call_expression),
++      choice($._identifier, $.call_expression),
+       ',',
+-      commaSep1(choice($.identifier, $.call_expression)),
++      commaSep1(choice($._identifier, $.call_expression)),
+       ')'
+     ),
+ 
+@@ -1182,7 +1182,7 @@ module.exports = grammar({
+     ),
+     cray_pointer_pair: $ => seq(
+       '(',
+-      field('pointer', $.identifier),
++      field('pointer', $._identifier),
+       ',',
+       field('target', $._variable_declarator),
+       ')',
+@@ -1288,8 +1288,8 @@ module.exports = grammar({
+ 
+     keyword_statement: $ => choice(
+       caseInsensitive('continue'),
+-      seq(caseInsensitive('cycle'), optional($.identifier)),
+-      seq(caseInsensitive('exit'), optional($.identifier)),
++      seq(caseInsensitive('cycle'), optional($._identifier)),
++      seq(caseInsensitive('exit'), optional($._identifier)),
+       seq(
+         whiteSpacedKeyword('go', 'to'),
+         choice(
+@@ -1327,7 +1327,7 @@ module.exports = grammar({
+     data_set: $ => prec(1, seq(
+       commaSep1(
+         choice(
+-          $.identifier,
++          $._identifier,
+           $.implied_do_loop_expression,
+           $.call_expression,  // For array indexing
+           $.derived_type_member_expression
+@@ -1339,7 +1339,7 @@ module.exports = grammar({
+       '/',
+       commaSep1(seq(
+         optional(prec(1,
+-          seq(field('repeat', choice($.number_literal, $.identifier)), '*')
++          seq(field('repeat', choice($.number_literal, $._identifier)), '*')
+         )),
+         choice(
+           $.number_literal,
+@@ -1349,7 +1349,7 @@ module.exports = grammar({
+           // Only constants allowed here, so can't have general expression as child
+           alias($._signed_literal, $.unary_expression),
+           $.null_literal,
+-          $.identifier,
++          $._identifier,
+           $.call_expression
+         )
+       )),
+@@ -1421,7 +1421,7 @@ module.exports = grammar({
+     ),
+ 
+     concurrent_control: $ => seq(
+-      $.identifier,
++      $._identifier,
+       '=',
+       field('initial', $._expression),
+       ':',
+@@ -1439,7 +1439,7 @@ module.exports = grammar({
+           caseInsensitive('local_init'),
+           caseInsensitive('shared'),
+         ),
+-        '(', commaSep1($.identifier), ')'
++        '(', commaSep1($._identifier), ')'
+       ),
+       seq(
+         caseInsensitive('default'),
+@@ -1447,7 +1447,7 @@ module.exports = grammar({
+       ),
+       seq(
+         caseInsensitive('reduce'),
+-        '(', $.binary_op, ':', commaSep1($.identifier), ')',
++        '(', $.binary_op, ':', commaSep1($._identifier), ')',
+       ),
+     ),
+     binary_op: $ => choice('+', '*', /(\.\w+\.|\w+)/),
+@@ -1548,7 +1548,7 @@ module.exports = grammar({
+     ),
+ 
+     triplet_spec: $ => seq(
+-      $.identifier,
++      $._identifier,
+       '=',
+       $._expression,
+       ':',
+@@ -1668,7 +1668,7 @@ module.exports = grammar({
+             whiteSpacedKeyword('class', 'is')
+           ),
+           choice(
+-            seq('(', field('type', choice($.intrinsic_type, $.identifier)), ')'),
++            seq('(', field('type', choice($.intrinsic_type, $._identifier)), ')'),
+           ),
+         ),
+         $.class_default
+@@ -1723,7 +1723,7 @@ module.exports = grammar({
+     ),
+ 
+     association: $ => seq(
+-      field('name', $.identifier),
++      field('name', $._identifier),
+       '=>',
+       field('selector', $._expression)
+     ),
+@@ -1852,7 +1852,7 @@ module.exports = grammar({
+       caseInsensitive('enumerator'),
+       optional('::'),
+       commaSep1(field('declarator', choice(
+-        $.identifier,
++        $._identifier,
+         alias($._declaration_assignment, $.init_declarator),
+       )))
+     ),
+@@ -1911,7 +1911,7 @@ module.exports = grammar({
+     _io_expressions: $ => prec(1, choice(
+       '*',
+       $.prefixed_string_literal,
+-      $.identifier,
++      $._identifier,
+       $.derived_type_member_expression,
+       $.concatenation_expression,
+       $.math_expression,
+@@ -1929,12 +1929,12 @@ module.exports = grammar({
+       optional(field('type', seq(
+         choice(
+           $.intrinsic_type,
+-          $.identifier,
++          $._identifier,
+         ),
+         '::'
+       ))),
+       commaSep1(field('allocation', choice(
+-        $.identifier,
++        $._identifier,
+         $.derived_type_member_expression,
+         $.sized_allocation,
+         $.coarray_allocation,
+@@ -1960,7 +1960,7 @@ module.exports = grammar({
+     deallocate_statement: $ => seq(
+       caseInsensitive('deallocate'),
+       '(',
+-      commaSep1(choice($.identifier, $.derived_type_member_expression)),
++      commaSep1(choice($._identifier, $.derived_type_member_expression)),
+       optional(seq(',', commaSep1($.keyword_argument))),
+       ')',
+     ),
+@@ -1968,7 +1968,7 @@ module.exports = grammar({
+     nullify_statement: $ => seq(
+       caseInsensitive('nullify'),
+       '(',
+-      commaSep1(choice($.identifier, $.derived_type_member_expression)),
++      commaSep1(choice($._identifier, $.derived_type_member_expression)),
+       ')',
+     ),
+ 
+@@ -1988,7 +1988,7 @@ module.exports = grammar({
+       caseInsensitive('assign'),
+       $.number_literal,
+       caseInsensitive('to'),
+-      $.identifier
++      $._identifier
+     ),
+ 
+     // Expressions
+@@ -2000,7 +2000,7 @@ module.exports = grammar({
+       $.boolean_literal,
+       $.array_literal,
+       $.null_literal,
+-      $.identifier,
++      $._identifier,
+       $.derived_type_member_expression,
+       $.logical_expression,
+       $.relational_expression,
+@@ -2012,7 +2012,6 @@ module.exports = grammar({
+       $.implied_do_loop_expression,
+       $.coarray_expression,
+       $.conditional_expression,
+-      $.macro_identifier
+     ),
+ 
+     parenthesized_expression: $ => seq(
+@@ -2024,7 +2023,7 @@ module.exports = grammar({
+     derived_type_member_expression: $ => prec.right(PREC.TYPE_MEMBER, seq(
+       $._expression,
+       '%',
+-      alias($.identifier, $.type_member)
++      alias($._identifier, $.type_member)
+     )),
+ 
+     logical_expression: $ => {
+@@ -2150,7 +2149,7 @@ module.exports = grammar({
+ 
+     // precedence is used to prevent conflict with assignment expression
+     keyword_argument: $ => prec(1, seq(
+-      field("name",$.identifier),
++      field("name",$._identifier),
+       field("equal", '='),
+       field("value",choice($._expression, $.assumed_size, $.assumed_shape))
+     )),
+@@ -2172,11 +2171,11 @@ module.exports = grammar({
+ 
+     assumed_rank: $ => '..',
+ 
+-    block_label_start_expression: $ => seq(alias($.identifier, 'label'), ':'),
+-    _block_label: $ => alias($.identifier, $.block_label),
++    block_label_start_expression: $ => seq(alias($._identifier, 'label'), ':'),
++    _block_label: $ => alias($._identifier, $.block_label),
+ 
+     loop_control_expression: $ => seq(
+-      $.identifier,
++      $._identifier,
+       '=',
+       $._expression,
+       ',',
+@@ -2205,9 +2204,9 @@ module.exports = grammar({
+ 
+     complex_literal: $ => seq(
+       '(',
+-      choice($.number_literal, $.identifier, $.unary_expression),
++      choice($.number_literal, $._identifier, $.unary_expression),
+       ',',
+-      choice($.number_literal, $.identifier, $.unary_expression),
++      choice($.number_literal, $._identifier, $.unary_expression),
+       ')'
+     ),
+ 
+@@ -2243,7 +2242,7 @@ module.exports = grammar({
+       caseInsensitive('null'),
+       '(',
+       optional(field('mold', choice(
+-        $.identifier,
++        $._identifier,
+         $.derived_type_member_expression,
+       ))),
+       ')',
+@@ -2288,7 +2287,7 @@ module.exports = grammar({
+ 
+     coarray_declarator: $ => prec.right(seq(
+       choice(
+-        $.identifier,
++        $._identifier,
+         $.sized_declarator,
+       ),
+       alias($.coarray_index, $.coarray_size),
+@@ -2451,6 +2450,11 @@ module.exports = grammar({
+       caseInsensitive('write', false),
+     ),
+ 
++    _identifier: $ => choice(
++      $.identifier,
++      $.macro_identifier,
++    ),
++
+     comment: $ => token(seq('!', /.*/)),
+ 
+     end_of_statement: $ => choice(';', $._external_end_of_statement),
+@@ -2565,7 +2569,7 @@ function preprocIf(suffix, content, precedence = 0) {
+ 
+     ['preproc_ifdef' + suffix]: $ => prec(precedence, seq(
+       choice(preprocessor('ifdef'), preprocessor('ifndef')),
+-      field('name', $.identifier),
++      field('name', $._identifier),
+       optional(preprocComment($)),
+       field('content', content($)),
+       field('alternative', optional(alternativeBlock($))),
+@@ -2589,7 +2593,7 @@ function preprocIf(suffix, content, precedence = 0) {
+ 
+     ['preproc_elifdef' + suffix]: $ => prec(precedence, seq(
+       choice(preprocessor('elifdef'), preprocessor('elifndef')),
+-      field('name', $.identifier),
++      field('name', $._identifier),
+       optional(preprocComment($)),
+       field('content', content($)),
+       field('alternative', optional(alternativeBlock($))),
+diff --git a/test/corpus/constructs.txt b/test/corpus/constructs.txt
+index f05081f..b949051 100644
+--- a/test/corpus/constructs.txt
++++ b/test/corpus/constructs.txt
+@@ -14,7 +14,8 @@ END PROGRAM TEST
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (end_program_statement
+       (whitespace)
+@@ -22,12 +23,14 @@ END PROGRAM TEST
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -83,7 +86,8 @@ end module
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (private_statement)
+@@ -92,13 +96,15 @@ end module
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (interface
+       (interface_statement
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (procedure_statement
+@@ -106,14 +112,16 @@ end module
+           (whitespace))
+         (whitespace)
+         (method_name
+-          (name)))
++          (name
++            (identifier))))
+       (whitespace)
+       (procedure_statement
+         (procedure_kind
+           (whitespace))
+         (whitespace)
+         (method_name
+-          (name)))
++          (name
++            (identifier))))
+       (whitespace)
+       (end_interface_statement
+         (whitespace)
+@@ -234,7 +242,8 @@ end module
+       (function
+         (function_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier)
+             (whitespace)
+@@ -262,7 +271,8 @@ end module
+       (function
+         (function_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier)
+             (whitespace)
+@@ -315,7 +325,8 @@ end interface
+     (subroutine
+       (subroutine_statement
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (parameters
+           (identifier)
+           (identifier)
+@@ -349,13 +360,15 @@ end interface
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (whitespace)
+     (function
+       (function_statement
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (parameters
+           (identifier)
+           (identifier))
+@@ -385,7 +398,8 @@ end interface
+       (end_function_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (end_interface_statement
+       (whitespace)
+@@ -420,7 +434,8 @@ end interface
+     (subroutine
+       (subroutine_statement
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (parameters
+           (identifier)
+           (identifier)
+@@ -454,13 +469,15 @@ end interface
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (whitespace)
+     (function
+       (function_statement
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (parameters
+           (identifier)
+           (identifier))
+@@ -490,7 +507,8 @@ end interface
+       (end_function_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (end_interface_statement
+       (whitespace)
+@@ -511,7 +529,8 @@ end interface
+   (interface
+     (interface_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (procedure_statement
+@@ -519,14 +538,16 @@ end interface
+         (whitespace))
+       (whitespace)
+       (method_name
+-        (name)))
++        (name
++          (identifier))))
+     (whitespace)
+     (procedure_statement
+       (procedure_kind
+         (whitespace))
+       (whitespace)
+       (method_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_interface_statement
+       (whitespace)
+       (end_of_statement))))
+@@ -564,14 +585,16 @@ end interface operator (.not.)
+         (whitespace))
+       (whitespace)
+       (method_name
+-        (name)))
++        (name
++          (identifier))))
+     (whitespace)
+     (procedure_statement
+       (procedure_kind
+         (whitespace))
+       (whitespace)
+       (method_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_interface_statement
+       (whitespace)
+       (whitespace)
+@@ -592,12 +615,14 @@ end interface operator (.not.)
+         (whitespace))
+       (whitespace)
+       (method_name
+-        (name)))
++        (name
++          (identifier))))
+     (whitespace)
+     (function
+       (function_statement
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (parameters
+           (identifier))
+         (end_of_statement))
+@@ -651,7 +676,8 @@ end interface assignment (=)
+         (whitespace))
+       (whitespace)
+       (method_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_interface_statement
+       (whitespace)
+       (whitespace)
+@@ -681,7 +707,8 @@ interface operator(+) ; module procedure test_plus ; end interface
+         (whitespace))
+       (whitespace)
+       (method_name
+-        (name)))
++        (name
++          (identifier))))
+     (whitespace)
+     (whitespace)
+     (end_interface_statement
+@@ -704,13 +731,15 @@ end module
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (included_items
+         (whitespace)
+         (whitespace)
+@@ -779,7 +808,8 @@ END SUBROUTINE
+       (procedure_qualifier)
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier))
+       (end_of_statement))
+@@ -817,12 +847,14 @@ END SUBROUTINE
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (end_subroutine_statement
+       (whitespace)
+@@ -830,7 +862,8 @@ END SUBROUTINE
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier)
+         (whitespace)
+@@ -845,7 +878,8 @@ END SUBROUTINE
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (whitespace)
+       (language_binding
+         (identifier)
+@@ -861,7 +895,8 @@ END SUBROUTINE
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -888,7 +923,8 @@ END SUBROUTINE
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier)
+             (whitespace)
+@@ -989,7 +1025,8 @@ end function
+           (number_literal)))
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (comment)
+@@ -997,7 +1034,8 @@ end function
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (assignment_statement
+@@ -1014,17 +1052,20 @@ end function
+   (function
+     (function_statement
+       (derived_type
+-        (type_name))
++        (type_name
++          (identifier)))
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (comment)
+     (whitespace)
+     (variable_declaration
+       (derived_type
+-        (type_name))
++        (type_name
++          (identifier)))
+       (whitespace)
+       (whitespace)
+       (identifier))
+@@ -1033,7 +1074,8 @@ end function
+     (assignment_statement
+       (derived_type_member_expression
+         (identifier)
+-        (type_member))
++        (type_member
++          (identifier)))
+       (whitespace)
+       (whitespace)
+       (number_literal))
+@@ -1055,7 +1097,8 @@ end function
+           (number_literal)))
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier)
+         (whitespace)
+@@ -1074,7 +1117,8 @@ end function
+           (number_literal)))
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (whitespace)
+       (language_binding
+         (identifier)
+@@ -1090,7 +1134,8 @@ end function
+   (function
+     (function_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (whitespace)
+       (function_result
+         (identifier))
+@@ -1109,7 +1154,8 @@ end function
+   (function
+     (function_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (whitespace)
+       (language_binding
+         (identifier)
+@@ -1163,7 +1209,8 @@ end function test
+       (intrinsic_type)
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier)
+         (whitespace)
+@@ -1210,7 +1257,8 @@ end function test
+           (procedure_qualifier)
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (whitespace)
+           (function_result
+             (identifier))
+@@ -1235,7 +1283,8 @@ end function test
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier))
+           (end_of_statement))
+@@ -1271,14 +1320,16 @@ end function test
+           (procedure_qualifier)
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier))
+           (end_of_statement))
+         (whitespace)
+         (variable_declaration
+           (derived_type
+-            (type_name))
++            (type_name
++              (identifier)))
+           (whitespace)
+           (whitespace)
+           (identifier))
+@@ -1287,12 +1338,14 @@ end function test
+         (end_function_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))))
+     (end_function_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1334,13 +1387,15 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (derived_type_definition
+       (derived_type_statement
+         (whitespace)
+-        (type_name)
++        (type_name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (end_type_statement
+@@ -1353,7 +1408,8 @@ end program
+         (access_specifier)
+         (whitespace)
+         (whitespace)
+-        (type_name)
++        (type_name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (end_of_statement)
+@@ -1427,7 +1483,8 @@ end program
+           (whitespace)
+           (whitespace)
+           (method_name
+-            (name)))
++            (name
++              (identifier))))
+         (whitespace)
+         (comment)
+         (whitespace)
+@@ -1435,7 +1492,8 @@ end program
+           (procedure_kind)
+           (whitespace)
+           (method_name
+-            (name)))
++            (name
++              (identifier))))
+         (whitespace)
+         (comment)
+         (whitespace)
+@@ -1449,7 +1507,8 @@ end program
+           (whitespace)
+           (whitespace)
+           (method_name
+-            (name)))
++            (name
++              (identifier))))
+         (whitespace)
+         (procedure_statement
+           (procedure_kind)
+@@ -1463,10 +1522,12 @@ end program
+             (whitespace)
+             (whitespace)
+             (method_name
+-              (name)))
++              (name
++                (identifier))))
+           (whitespace)
+           (method_name
+-            (name)))
++            (name
++              (identifier))))
+         (whitespace)
+         (procedure_statement
+           (procedure_kind)
+@@ -1480,7 +1541,8 @@ end program
+             (whitespace)
+             (whitespace)
+             (method_name
+-              (name))))
++              (name
++                (identifier)))))
+         (whitespace)
+         (procedure_statement
+           (procedure_kind)
+@@ -1495,14 +1557,16 @@ end program
+             (whitespace)
+             (whitespace)
+             (method_name
+-              (name))))
++              (name
++                (identifier)))))
+         (whitespace)
+         (procedure_statement
+           (procedure_kind)
+           (whitespace)
+           (whitespace)
+           (method_name
+-            (name))
++            (name
++              (identifier)))
+           (whitespace)
+           (binding
+             (binding_name
+@@ -1510,19 +1574,22 @@ end program
+             (whitespace)
+             (whitespace)
+             (method_name
+-              (name))))
++              (name
++                (identifier)))))
+         (whitespace)
+         (procedure_statement
+           (procedure_kind)
+           (whitespace)
+           (whitespace)
+           (method_name
+-            (name))))
++            (name
++              (identifier)))))
+       (whitespace)
+       (end_type_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (whitespace)
+     (derived_type_definition
+@@ -1531,7 +1598,8 @@ end program
+         (abstract_specifier)
+         (whitespace)
+         (whitespace)
+-        (type_name)
++        (type_name
++          (identifier))
+         (derived_type_parameter_list
+           (identifier)
+           (whitespace)
+@@ -1608,7 +1676,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (derived_type_definition
+@@ -1619,13 +1688,15 @@ end program
+         (abstract_specifier)
+         (whitespace)
+         (whitespace)
+-        name: (type_name)
++        name: (type_name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (end_type_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (whitespace)
+     (derived_type_definition
+@@ -1637,13 +1708,15 @@ end program
+           (identifier))
+         (whitespace)
+         (whitespace)
+-        name: (type_name)
++        name: (type_name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (end_type_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (end_program_statement
+       (whitespace)
+@@ -1670,13 +1743,15 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (derived_type_definition
+       (derived_type_statement
+         (whitespace)
+-        (type_name)
++        (type_name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (derived_type_procedures
+@@ -1684,13 +1759,15 @@ end program
+         (whitespace)
+         (procedure_statement
+           (procedure_kind)
+-          (procedure_interface)
++          (procedure_interface
++            (identifier))
+           (whitespace)
+           (procedure_attribute)
+           (whitespace)
+           (whitespace)
+           (method_name
+-            (name))))
++            (name
++              (identifier)))))
+       (whitespace)
+       (end_type_statement
+         (whitespace)
+@@ -1705,7 +1782,8 @@ end program
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))
+         (whitespace)
+         (end_subroutine_statement
+@@ -1738,13 +1816,15 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (derived_type_definition
+       (derived_type_statement
+         (whitespace)
+-        (type_name)
++        (type_name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (derived_type_procedures
+@@ -1757,7 +1837,8 @@ end program test
+           (whitespace)
+           (whitespace)
+           (method_name
+-            (name)))
++            (name
++              (identifier))))
+         (whitespace)
+         (procedure_statement
+           (procedure_kind)
+@@ -1766,17 +1847,20 @@ end program test
+           (whitespace)
+           (whitespace)
+           (method_name
+-            (name))))
++            (name
++              (identifier)))))
+       (whitespace)
+       (end_type_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1796,18 +1880,21 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (derived_type_definition
+       (derived_type_statement
+         (whitespace)
+-        (type_name)
++        (type_name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (variable_declaration
+         (procedure
+-          (procedure_interface)
++          (procedure_interface
++            (identifier))
+           (whitespace)
+           (procedure_attribute))
+         (whitespace)
+@@ -1828,7 +1915,8 @@ end program test
+       (whitespace)
+       (variable_declaration
+         (procedure
+-          (procedure_interface)
++          (procedure_interface
++            (identifier))
+           (whitespace)
+           (procedure_attribute)
+           (whitespace)
+@@ -1841,12 +1929,14 @@ end program test
+       (end_type_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1871,9 +1961,11 @@ END SUBMODULE ConstructorMethods_child
+   (submodule
+     (submodule_statement
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (implicit_statement
+       (whitespace)
+@@ -1885,16 +1977,20 @@ END SUBMODULE ConstructorMethods_child
+     (end_submodule_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (submodule
+     (submodule_statement
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (implicit_statement
+       (whitespace)
+@@ -1906,7 +2002,8 @@ END SUBMODULE ConstructorMethods_child
+     (end_submodule_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1937,7 +2034,8 @@ END MODULE BoundingBox_Method
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (private_statement)
+     (end_of_statement)
+@@ -1952,7 +2050,8 @@ END MODULE BoundingBox_Method
+           (procedure_qualifier)
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier)
+             (whitespace)
+@@ -1963,7 +2062,8 @@ END MODULE BoundingBox_Method
+         (whitespace)
+         (variable_declaration
+           (derived_type
+-            (type_name))
++            (type_name
++              (identifier)))
+           (whitespace)
+           (type_qualifier)
+           (whitespace)
+@@ -1974,7 +2074,8 @@ END MODULE BoundingBox_Method
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (end_interface_statement
+         (whitespace)
+@@ -1988,7 +2089,8 @@ END MODULE BoundingBox_Method
+           (procedure_qualifier)
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier))
+           (whitespace)
+@@ -1998,7 +2100,8 @@ END MODULE BoundingBox_Method
+         (whitespace)
+         (variable_declaration
+           (derived_type
+-            (type_name))
++            (type_name
++              (identifier)))
+           (whitespace)
+           (type_qualifier)
+           (whitespace)
+@@ -2009,7 +2112,8 @@ END MODULE BoundingBox_Method
+         (end_function_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (end_interface_statement
+         (whitespace)
+@@ -2017,7 +2121,8 @@ END MODULE BoundingBox_Method
+     (end_module_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -2044,7 +2149,8 @@ end module test
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (interface
+@@ -2056,13 +2162,15 @@ end module test
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))
+         (whitespace)
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (whitespace)
+       (end_interface_statement
+@@ -2075,7 +2183,8 @@ end module test
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier)
+             (whitespace)
+@@ -2086,7 +2195,8 @@ end module test
+         (whitespace)
+         (variable_declaration
+           (procedure
+-            (procedure_interface))
++            (procedure_interface
++              (identifier)))
+           (whitespace)
+           (whitespace)
+           (identifier))
+@@ -2094,7 +2204,8 @@ end module test
+         (whitespace)
+         (variable_declaration
+           (procedure
+-            (procedure_interface))
++            (procedure_interface
++              (identifier)))
+           (whitespace)
+           (type_qualifier)
+           (whitespace)
+@@ -2125,12 +2236,14 @@ end module test
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))))
+     (end_module_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -2161,7 +2274,8 @@ end program block_demo
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (implicit_statement
+@@ -2216,7 +2330,8 @@ end program block_demo
+       (end_of_statement)
+       (whitespace)
+       (block_construct
+-        (block_label_start_expression)
++        (block_label_start_expression
++          (identifier))
+         (whitespace)
+         (end_of_statement)
+         (whitespace)
+@@ -2241,7 +2356,8 @@ end program block_demo
+         (end_block_construct_statement
+           (whitespace)
+           (whitespace)
+-          (block_label)))
++          (block_label
++            (identifier))))
+       (end_of_statement)
+       (whitespace)
+       (end_block_construct_statement
+@@ -2257,7 +2373,8 @@ end program block_demo
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -2277,7 +2394,8 @@ end module enumeration_mod
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (enumeration_type
+@@ -2287,7 +2405,8 @@ end module enumeration_mod
+         (access_specifier)
+         (whitespace)
+         (whitespace)
+-        (type_name))
++        (type_name
++          (identifier)))
+       (whitespace)
+       (enumerator_statement
+         (whitespace)
+@@ -2306,12 +2425,14 @@ end module enumeration_mod
+         (whitespace)
+         (whitespace)
+         (whitespace)
+-        (name)))
++        (name
++          (identifier))))
+     (end_of_statement)
+     (end_module_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -2376,13 +2497,15 @@ Block Data (Obsolescent)
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2407,13 +2530,15 @@ Block Data (Obsolescent)
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2440,13 +2565,15 @@ Block Data (Obsolescent)
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2472,13 +2599,15 @@ Block Data (Obsolescent)
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2503,13 +2632,15 @@ Block Data (Obsolescent)
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2535,13 +2666,15 @@ Block Data (Obsolescent)
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2561,20 +2694,23 @@ Block Data (Obsolescent)
+     (whitespace)
+     (end_block_data_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (whitespace)
+   (block_data
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2596,20 +2732,23 @@ Block Data (Obsolescent)
+       (whitespace)
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (whitespace)
+   (block_data
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2630,20 +2769,23 @@ Block Data (Obsolescent)
+     (end_block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (whitespace)
+   (block_data
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2663,20 +2805,23 @@ Block Data (Obsolescent)
+     (whitespace)
+     (end_block_data_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (whitespace)
+   (block_data
+     (block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+@@ -2697,5 +2842,6 @@ Block Data (Obsolescent)
+     (end_block_data_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+diff --git a/test/corpus/cudafortran.txt b/test/corpus/cudafortran.txt
+index a0da1f4..7e1759c 100644
+--- a/test/corpus/cudafortran.txt
++++ b/test/corpus/cudafortran.txt
+@@ -14,7 +14,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -42,7 +43,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -67,7 +69,8 @@ end function
+           (number_literal)))
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (comment)
+@@ -75,7 +78,8 @@ end function
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (assignment_statement
+@@ -109,7 +113,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (subroutine_call
+diff --git a/test/corpus/expressions.txt b/test/corpus/expressions.txt
+index c4b4bfe..221525c 100644
+--- a/test/corpus/expressions.txt
++++ b/test/corpus/expressions.txt
+@@ -37,7 +37,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -272,7 +273,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -390,7 +392,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -427,7 +430,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -544,7 +548,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -677,7 +682,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (pointer_association_statement
+@@ -700,7 +706,8 @@ END PROGRAM
+     (pointer_association_statement
+       (derived_type_member_expression
+         (identifier)
+-        (type_member))
++        (type_member
++          (identifier)))
+       (whitespace)
+       (whitespace)
+       (identifier))
+@@ -725,13 +732,15 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+       (derived_type_member_expression
+         (identifier)
+-        (type_member))
++        (type_member
++          (identifier)))
+       (whitespace)
+       (whitespace)
+       (identifier))
+@@ -743,14 +752,16 @@ END PROGRAM
+       (whitespace)
+       (derived_type_member_expression
+         (identifier)
+-        (type_member)))
++        (type_member
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (assignment_statement
+       (call_expression
+         (derived_type_member_expression
+           (identifier)
+-          (type_member))
++          (type_member
++            (identifier)))
+         (argument_list
+           (extent_specifier
+             (number_literal)
+@@ -786,7 +797,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -945,7 +957,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -1205,7 +1218,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -1284,7 +1298,8 @@ END PROGRAM
+     (assignment_statement
+       left: (derived_type_member_expression
+         (identifier)
+-        (type_member))
++        (type_member
++          (identifier)))
+       (whitespace)
+       (whitespace)
+       right: (call_expression
+@@ -1339,14 +1354,16 @@ end program use_type_bound_procedures
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (subroutine_call
+       (whitespace)
+       (derived_type_member_expression
+         (identifier)
+-        (type_member))
++        (type_member
++          (identifier)))
+       (argument_list))
+     (end_of_statement)
+     (whitespace)
+@@ -1358,14 +1375,17 @@ end program use_type_bound_procedures
+             (identifier)
+             (argument_list
+               (identifier)))
+-          (type_member))
+-        (type_member))
++          (type_member
++            (identifier)))
++        (type_member
++          (identifier)))
+       (argument_list))
+     (end_of_statement)
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1388,7 +1408,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (write_statement
+@@ -1447,7 +1468,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (print_statement
+@@ -1460,7 +1482,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1485,7 +1508,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -1540,8 +1564,7 @@ end program
+           (ERROR
+             (ERROR
+               (number_literal))
+-            (user_defined_operator_name)
+-            (number_literal))
++            (user_defined_operator_name))
+           (whitespace)
+           (whitespace)
+           (number_literal))))
+@@ -1574,7 +1597,8 @@ end program array_constructors
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (implicit_statement
+@@ -1739,7 +1763,8 @@ end program array_constructors
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1774,7 +1799,8 @@ end subroutine foo
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -1891,7 +1917,8 @@ end subroutine foo
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -1964,7 +1991,8 @@ end subroutine foo
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1984,7 +2012,8 @@ end subroutine test
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       parameters: (parameters
+         (identifier)
+         (whitespace)
+@@ -2048,7 +2077,8 @@ end subroutine test
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -2071,7 +2101,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -2188,7 +2219,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -2206,7 +2238,8 @@ end
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -2257,7 +2290,8 @@ end
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+diff --git a/test/corpus/floating.txt b/test/corpus/floating.txt
+index dcb6a23..e301c45 100644
+--- a/test/corpus/floating.txt
++++ b/test/corpus/floating.txt
+@@ -165,7 +165,8 @@ common /blk/ a, b
+   (common_statement
+     (whitespace)
+     (variable_group
+-      (name)
++      (name
++        (identifier))
+       (whitespace)
+       (identifier)
+       (whitespace)
+@@ -187,7 +188,8 @@ end type t
+     (derived_type_statement
+       (whitespace)
+       (whitespace)
+-      (type_name)
++      (type_name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -199,7 +201,8 @@ end type t
+     (end_type_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -236,7 +239,8 @@ end interface
+     (subroutine
+       (subroutine_statement
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (parameters
+           (identifier))
+         (end_of_statement))
+@@ -251,7 +255,8 @@ end interface
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (end_interface_statement
+       (whitespace)
+@@ -269,7 +274,8 @@ use iso_fortran_env, only: int32
+   (use_statement
+     (whitespace)
+     (module_name
+-      (name))
++      (name
++        (identifier)))
+     (included_items
+       (whitespace)
+       (whitespace)
+@@ -462,7 +468,8 @@ a = 1
+     (derived_type_statement
+       (whitespace)
+       (whitespace)
+-      (type_name)
++      (type_name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -474,7 +481,8 @@ a = 1
+     (end_type_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (variable_declaration
+     (intrinsic_type)
+@@ -517,7 +525,8 @@ end
+       (derived_type_statement
+         (whitespace)
+         (whitespace)
+-        (type_name)
++        (type_name
++          (identifier))
+         (end_of_statement))
+       (end_type_statement
+         (whitespace)
+@@ -532,7 +541,8 @@ end
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))
+         (end_subroutine_statement
+           (end_of_statement))))))
+@@ -636,7 +646,8 @@ end interface
+     (module
+       (module_statement
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement))
+       (internal_procedures
+         (contains_statement)
+@@ -645,18 +656,21 @@ end interface
+         (subroutine
+           (subroutine_statement
+             (whitespace)
+-            (name)
++            (name
++              (identifier))
+             (end_of_statement))
+           (whitespace)
+           (end_subroutine_statement
+             (whitespace)
+             (whitespace)
+-            (name)
++            (name
++              (identifier))
+             (end_of_statement))))
+       (end_module_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (preproc_else
+       (interface
+@@ -666,13 +680,15 @@ end interface
+         (subroutine
+           (subroutine_statement
+             (whitespace)
+-            (name)
++            (name
++              (identifier))
+             (end_of_statement))
+           (whitespace)
+           (end_subroutine_statement
+             (whitespace)
+             (whitespace)
+-            (name)
++            (name
++              (identifier))
+             (end_of_statement)))
+         (end_interface_statement
+           (whitespace)
+diff --git a/test/corpus/line_continuations.txt b/test/corpus/line_continuations.txt
+index 440f58e..8d0fa6f 100644
+--- a/test/corpus/line_continuations.txt
++++ b/test/corpus/line_continuations.txt
+@@ -14,7 +14,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (write_statement
+@@ -65,7 +66,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (write_statement
+@@ -111,7 +113,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -129,7 +132,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -151,7 +155,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (internal_procedures
+       (contains_statement)
+@@ -160,7 +165,8 @@ end program test
+       (function
+         (function_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (whitespace)
+             (whitespace)
+@@ -183,12 +189,14 @@ end program test
+         (end_function_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))))
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -207,7 +215,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (write_statement
+@@ -247,7 +256,8 @@ end program ! comment
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -277,7 +287,8 @@ end program ! comment
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (whitespace)
+           (end_of_statement))
+         (comment)
+@@ -285,7 +296,8 @@ end program ! comment
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (whitespace)
+           (end_of_statement))))
+     (comment)
+@@ -318,7 +330,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (print_statement
+@@ -392,7 +405,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (statement_label)
+     (whitespace)
+@@ -438,7 +452,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -467,7 +482,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -484,7 +500,8 @@ end program main
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (comment)
+@@ -500,5 +517,6 @@ end program main
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+diff --git a/test/corpus/preprocessor.txt b/test/corpus/preprocessor.txt
+index 1795dcd..4c7c363 100644
+--- a/test/corpus/preprocessor.txt
++++ b/test/corpus/preprocessor.txt
+@@ -169,12 +169,14 @@ end subroutine foo4
+     content: (subroutine
+       (subroutine_statement
+         (whitespace)
+-        name: (name)
++        name: (name
++          (identifier))
+         (end_of_statement))
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement))))
+   (preproc_ifdef
+     (whitespace)
+@@ -182,12 +184,14 @@ end subroutine foo4
+     content: (subroutine
+       (subroutine_statement
+         (whitespace)
+-        name: (name)
++        name: (name
++          (identifier))
+         (end_of_statement))
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     content: (preproc_def
+       (whitespace)
+@@ -203,12 +207,14 @@ end subroutine foo4
+         content: (subroutine
+           (subroutine_statement
+             (whitespace)
+-            name: (name)
++            name: (name
++              (identifier))
+             (end_of_statement))
+           (end_subroutine_statement
+             (whitespace)
+             (whitespace)
+-            (name)
++            (name
++              (identifier))
+             (end_of_statement)))
+         content: (preproc_def
+           (whitespace)
+@@ -223,12 +229,14 @@ end subroutine foo4
+     content: (subroutine
+       (subroutine_statement
+         (whitespace)
+-        name: (name)
++        name: (name
++          (identifier))
+         (end_of_statement))
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (whitespace)
+     (inline_preproc_comment)))
+@@ -265,12 +273,14 @@ end subroutine foo5
+     content: (subroutine
+       (subroutine_statement
+         (whitespace)
+-        name: (name)
++        name: (name
++          (identifier))
+         (end_of_statement))
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     alternative: (preproc_elifdef
+       (whitespace)
+@@ -278,12 +288,14 @@ end subroutine foo5
+       content: (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))))
+   (preproc_ifdef
+     (whitespace)
+@@ -291,12 +303,14 @@ end subroutine foo5
+     content: (subroutine
+       (subroutine_statement
+         (whitespace)
+-        name: (name)
++        name: (name
++          (identifier))
+         (end_of_statement))
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     alternative: (preproc_elifdef
+       (whitespace)
+@@ -304,23 +318,27 @@ end subroutine foo5
+       content: (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       alternative: (preproc_else
+         content: (subroutine
+           (subroutine_statement
+             (whitespace)
+-            name: (name)
++            name: (name
++              (identifier))
+             (end_of_statement))
+           (end_subroutine_statement
+             (whitespace)
+             (whitespace)
+-            (name)
++            (name
++              (identifier))
+             (end_of_statement)))))))
+ 
+ ================================================================================
+@@ -355,12 +373,14 @@ end subroutine e
+     content: (subroutine
+       (subroutine_statement
+         (whitespace)
+-        name: (name)
++        name: (name
++          (identifier))
+         (end_of_statement))
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     alternative: (preproc_elif
+       (whitespace)
+@@ -369,12 +389,14 @@ end subroutine e
+       content: (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))))
+   (preproc_if
+     (whitespace)
+@@ -384,12 +406,14 @@ end subroutine e
+     content: (subroutine
+       (subroutine_statement
+         (whitespace)
+-        name: (name)
++        name: (name
++          (identifier))
+         (end_of_statement))
+       (end_subroutine_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     alternative: (preproc_elifdef
+       (whitespace)
+@@ -397,23 +421,27 @@ end subroutine e
+       content: (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       alternative: (preproc_else
+         content: (subroutine
+           (subroutine_statement
+             (whitespace)
+-            name: (name)
++            name: (name
++              (identifier))
+             (end_of_statement))
+           (end_subroutine_statement
+             (whitespace)
+             (whitespace)
+-            (name)
++            (name
++              (identifier))
+             (end_of_statement)))))))
+ 
+ ================================================================================
+@@ -544,7 +572,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (preproc_call
+       (preproc_directive)
+@@ -560,7 +589,8 @@ end program test
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))
+         (preproc_call
+           (preproc_directive)
+@@ -580,7 +610,8 @@ end program test
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (preproc_call
+         (preproc_directive)
+@@ -589,7 +620,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -610,13 +642,15 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (included_items
+         (whitespace)
+         (whitespace)
+@@ -635,7 +669,8 @@ end program
+       content: (use_statement
+         (whitespace)
+         (module_name
+-          (name)))
++          (name
++            (identifier))))
+       content: (end_of_statement))
+     (end_program_statement
+       (whitespace)
+@@ -665,13 +700,15 @@ end module foo
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (derived_type_definition
+       (derived_type_statement
+         (whitespace)
+-        (type_name)
++        (type_name
++          (identifier))
+         (end_of_statement))
+       (preproc_include
+         (whitespace)
+@@ -702,17 +739,20 @@ end module foo
+             (whitespace)
+             (whitespace)
+             (method_name
+-              (name)))))
++              (name
++                (identifier))))))
+       (whitespace)
+       (end_type_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (end_module_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -741,7 +781,8 @@ end module foo
+   (module
+     (module_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (internal_procedures
+       (contains_statement)
+@@ -750,13 +791,15 @@ end module foo
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (whitespace)
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (preproc_ifdef
+         (whitespace)
+@@ -765,30 +808,35 @@ end module foo
+         content: (subroutine
+           (subroutine_statement
+             (whitespace)
+-            name: (name)
++            name: (name
++              (identifier))
+             (end_of_statement))
+           (whitespace)
+           (end_subroutine_statement
+             (whitespace)
+             (whitespace)
+-            (name)
++            (name
++              (identifier))
+             (end_of_statement))))
+       (whitespace)
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (whitespace)
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))))
+     (end_module_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -819,7 +867,8 @@ end module foo
+   (module
+     (module_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (internal_procedures
+       (contains_statement)
+@@ -828,7 +877,8 @@ end module foo
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (whitespace)
+         (variable_declaration
+@@ -873,24 +923,28 @@ end module foo
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (whitespace)
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (whitespace)
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))))
+     (end_module_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -920,7 +974,8 @@ end module foo
+   (module
+     (module_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (internal_procedures
+       (contains_statement)
+@@ -929,7 +984,8 @@ end module foo
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (whitespace)
+         (variable_declaration
+@@ -962,24 +1018,28 @@ end module foo
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (whitespace)
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          name: (name)
++          name: (name
++            (identifier))
+           (end_of_statement))
+         (whitespace)
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))))
+     (end_module_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1015,7 +1075,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (implicit_statement
+@@ -1134,13 +1195,15 @@ end module
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (interface
+       (interface_statement
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (procedure_statement
+@@ -1148,7 +1211,8 @@ end module
+           (whitespace))
+         (whitespace)
+         (method_name
+-          (name)))
++          (name
++            (identifier))))
+       (preproc_ifdef
+         (whitespace)
+         (identifier)
+@@ -1158,7 +1222,8 @@ end module
+             (whitespace))
+           (whitespace)
+           (method_name
+-            (name))))
++            (name
++              (identifier)))))
+       (whitespace)
+       (end_interface_statement
+         (whitespace)
+@@ -1198,7 +1263,8 @@ Preprocessor in specification part
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (implicit_statement
+@@ -1307,7 +1373,8 @@ Preprocessor in specification part
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1343,7 +1410,8 @@ Baz */
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+diff --git a/test/corpus/regressions.txt b/test/corpus/regressions.txt
+index 3bc1032..bf95f92 100644
+--- a/test/corpus/regressions.txt
++++ b/test/corpus/regressions.txt
+@@ -24,13 +24,15 @@ end program example_padl
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (included_items
+         (whitespace)
+         (whitespace)
+@@ -45,7 +47,8 @@ end program example_padl
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (included_items
+         (whitespace)
+         (whitespace)
+@@ -59,7 +62,8 @@ end program example_padl
+     (whitespace)
+     (variable_declaration
+       (derived_type
+-        (type_name))
++        (type_name
++          (identifier)))
+       (whitespace)
+       (whitespace)
+       (identifier))
+@@ -109,7 +113,8 @@ end program example_padl
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================
+@@ -132,12 +137,14 @@ end program foo
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (if_statement
+       (block_if_statement
+-        (block_label_start_expression)
++        (block_label_start_expression
++          (identifier))
+         (whitespace)
+         (whitespace)
+         (parenthesized_expression
+@@ -153,7 +160,8 @@ end program foo
+         (whitespace)
+         (else_clause
+           (whitespace)
+-          (block_label)
++          (block_label
++            (identifier))
+           (end_of_statement)
+           (whitespace)
+           (subroutine_call
+@@ -164,12 +172,14 @@ end program foo
+         (whitespace)
+         (end_if_statement
+           (whitespace)
+-          (block_label))))
++          (block_label
++            (identifier)))))
+     (end_of_statement)
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================
+@@ -191,7 +201,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (if_statement
+@@ -233,7 +244,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -252,7 +264,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -269,7 +282,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (assignment_statement
+@@ -325,7 +339,8 @@ Multiple array assignments
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier)
+         (whitespace)
+@@ -454,5 +469,6 @@ Multiple array assignments
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+diff --git a/test/corpus/statements.txt b/test/corpus/statements.txt
+index 9964537..ab1c4b8 100644
+--- a/test/corpus/statements.txt
++++ b/test/corpus/statements.txt
+@@ -35,7 +35,8 @@ end subroutine foo
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (include_statement
+@@ -84,7 +85,8 @@ end subroutine foo
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))
+         (whitespace)
+         (include_statement
+@@ -95,7 +97,8 @@ end subroutine foo
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))))
+     (end_program_statement
+       (whitespace)
+@@ -104,17 +107,20 @@ end subroutine foo
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (end_module_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (include_statement
+@@ -145,7 +151,8 @@ end subroutine foo
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -171,19 +178,22 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (included_items
+         (whitespace)
+         (whitespace)
+@@ -196,7 +206,8 @@ END PROGRAM
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (included_items
+         (whitespace)
+         (identifier)))
+@@ -207,7 +218,8 @@ END PROGRAM
+       (whitespace)
+       (whitespace)
+       (module_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (use_statement
+@@ -215,18 +227,21 @@ END PROGRAM
+       (whitespace)
+       (whitespace)
+       (module_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (included_items
+         (whitespace)
+         (whitespace)
+         (use_alias
+-          (local_name)
++          (local_name
++            (identifier))
+           (whitespace)
+           (whitespace)
+           (identifier))))
+@@ -236,10 +251,12 @@ END PROGRAM
+       (whitespace)
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (whitespace)
+       (use_alias
+-        (local_name)
++        (local_name
++          (identifier))
+         (whitespace)
+         (whitespace)
+         (identifier)))
+@@ -249,13 +266,15 @@ END PROGRAM
+       (whitespace)
+       (whitespace)
+       (module_name
+-        (name)))
++        (name
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (included_items
+         (whitespace)))
+     (end_of_statement)
+@@ -263,10 +282,12 @@ END PROGRAM
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (whitespace)
+       (use_alias
+-        (local_name)
++        (local_name
++          (identifier))
+         (whitespace)
+         (whitespace)
+         (identifier)))
+@@ -292,7 +313,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (implicit_statement
+@@ -343,12 +365,14 @@ END PROGRAM
+     (implicit_statement
+       (whitespace)
+       (derived_type
+-        (type_name))
++        (type_name
++          (identifier)))
+       (implicit_range
+         (implicit_range_letter))
+       (whitespace)
+       (derived_type
+-        (type_name))
++        (type_name
++          (identifier)))
+       (implicit_range
+         (implicit_range_letter)))
+     (end_of_statement)
+@@ -371,7 +395,8 @@ END MODULE
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (save_statement)
+@@ -407,7 +432,8 @@ END MODULE
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (private_statement)
+@@ -445,7 +471,8 @@ END MODULE
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (public_statement)
+@@ -495,7 +522,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -728,12 +756,14 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+       (derived_type
+-        (type_name))
++        (type_name
++          (identifier)))
+       (whitespace)
+       (whitespace)
+       (identifier))
+@@ -772,7 +802,8 @@ END PROGRAM
+     (whitespace)
+     (variable_declaration
+       (derived_type
+-        (type_name)
++        (type_name
++          (identifier))
+         (kind
+           (number_literal)
+           (whitespace)
+@@ -784,7 +815,8 @@ END PROGRAM
+     (whitespace)
+     (variable_declaration
+       (derived_type
+-        (type_name))
++        (type_name
++          (identifier)))
+       (whitespace)
+       (type_qualifier)
+       (whitespace)
+@@ -835,7 +867,8 @@ end module foo
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (internal_procedures
+       (contains_statement)
+@@ -843,7 +876,8 @@ end module foo
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier)
+             (whitespace)
+@@ -852,7 +886,8 @@ end module foo
+         (whitespace)
+         (variable_declaration
+           (derived_type
+-            (type_name))
++            (type_name
++              (identifier)))
+           (whitespace)
+           (type_qualifier)
+           (whitespace)
+@@ -872,12 +907,14 @@ end module foo
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier)
+             (whitespace)
+@@ -886,7 +923,8 @@ end module foo
+         (whitespace)
+         (variable_declaration
+           (derived_type
+-            (type_name))
++            (type_name
++              (identifier)))
+           (whitespace)
+           (type_qualifier)
+           (whitespace)
+@@ -908,12 +946,14 @@ end module foo
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (subroutine
+         (subroutine_statement
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier)
+             (whitespace)
+@@ -947,12 +987,14 @@ end module foo
+         (end_subroutine_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement))))
+     (end_module_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -975,7 +1017,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_modification
+@@ -1064,7 +1107,8 @@ END PROGRAM
+       (whitespace)
+       (identifier)
+       (whitespace)
+-      (common_block)
++      (common_block
++        (identifier))
+       (whitespace)
+       (identifier))
+     (end_of_statement)
+@@ -1117,7 +1161,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (do_loop
+@@ -1195,7 +1240,8 @@ END PROGRAM
+     (end_of_statement)
+     (whitespace)
+     (do_loop
+-      (block_label_start_expression)
++      (block_label_start_expression
++        (identifier))
+       (whitespace)
+       (do_statement
+         (whitespace)
+@@ -1242,7 +1288,8 @@ END PROGRAM
+       (end_do_loop_statement
+         (whitespace)
+         (whitespace)
+-        (block_label)))
++        (block_label
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (do_loop
+@@ -1319,7 +1366,8 @@ END PROGRAM TEST
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -1452,7 +1500,8 @@ END PROGRAM TEST
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1476,7 +1525,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (do_label_statement
+@@ -1555,7 +1605,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -1573,7 +1624,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (keyword_statement
+@@ -1641,7 +1693,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (if_statement
+@@ -1770,7 +1823,8 @@ END PROGRAM
+     (whitespace)
+     (if_statement
+       (block_if_statement
+-        (block_label_start_expression)
++        (block_label_start_expression
++          (identifier))
+         (whitespace)
+         (whitespace)
+         (parenthesized_expression
+@@ -1800,7 +1854,8 @@ END PROGRAM
+               (number_literal)))
+           (whitespace)
+           (whitespace)
+-          (block_label)
++          (block_label
++            (identifier))
+           (end_of_statement)
+           (whitespace)
+           (assignment_statement
+@@ -1846,7 +1901,8 @@ END PROGRAM
+         (whitespace)
+         (else_clause
+           (whitespace)
+-          (block_label)
++          (block_label
++            (identifier))
+           (end_of_statement)
+           (whitespace)
+           (assignment_statement
+@@ -1859,7 +1915,8 @@ END PROGRAM
+         (end_if_statement
+           (whitespace)
+           (whitespace)
+-          (block_label))))
++          (block_label
++            (identifier)))))
+     (end_of_statement)
+     (end_program_statement
+       (whitespace)
+@@ -1898,7 +1955,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (where_statement
+       (inline_where_statement
+@@ -1983,7 +2041,8 @@ end program
+     (end_of_statement)
+     (where_statement
+       (block_where_statement
+-        (block_label_start_expression)
++        (block_label_start_expression
++          (identifier))
+         (whitespace)
+         (parenthesized_expression
+           (relational_expression
+@@ -2012,7 +2071,8 @@ end program
+               (whitespace)
+               (number_literal)))
+           (whitespace)
+-          (block_label)
++          (block_label
++            (identifier))
+           (end_of_statement)
+           (whitespace)
+           (assignment_statement
+@@ -2027,7 +2087,8 @@ end program
+           (end_of_statement))
+         (elsewhere_clause
+           (whitespace)
+-          (block_label)
++          (block_label
++            (identifier))
+           (end_of_statement)
+           (whitespace)
+           (assignment_statement
+@@ -2038,7 +2099,8 @@ end program
+           (end_of_statement))
+         (end_where_statement
+           (whitespace)
+-          (block_label))))
++          (block_label
++            (identifier)))))
+     (end_of_statement)
+     (end_program_statement
+       (whitespace)
+@@ -2072,7 +2134,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (forall_statement
+       (inline_forall_statement
+@@ -2134,7 +2197,8 @@ END PROGRAM
+               (identifier)
+               (argument_list
+                 (identifier)))
+-            (type_member))
++            (type_member
++              (identifier)))
+           (whitespace)
+           (whitespace)
+           (call_expression
+@@ -2358,11 +2422,13 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (select_case_statement
+-      (block_label_start_expression)
++      (block_label_start_expression
++        (identifier))
+       (whitespace)
+       (whitespace)
+       (whitespace)
+@@ -2378,7 +2444,8 @@ END PROGRAM
+             (unary_expression
+               (number_literal))))
+         (whitespace)
+-        (block_label)
++        (block_label
++          (identifier))
+         (end_of_statement)
+         (whitespace)
+         (assignment_statement
+@@ -2394,7 +2461,8 @@ END PROGRAM
+         (case_value_range_list
+           (number_literal))
+         (whitespace)
+-        (block_label)
++        (block_label
++          (identifier))
+         (end_of_statement)
+         (whitespace)
+         (assignment_statement
+@@ -2411,7 +2479,8 @@ END PROGRAM
+             (number_literal)
+             (whitespace)))
+         (whitespace)
+-        (block_label)
++        (block_label
++          (identifier))
+         (end_of_statement)
+         (whitespace)
+         (assignment_statement
+@@ -2424,7 +2493,8 @@ END PROGRAM
+       (end_select_statement
+         (whitespace)
+         (whitespace)
+-        (block_label)))
++        (block_label
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (select_case_statement
+@@ -2551,7 +2621,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (statement_label)
+     (whitespace)
+@@ -2666,7 +2737,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (read_statement
+@@ -2778,7 +2850,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (print_statement
+@@ -2844,7 +2917,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -3008,7 +3082,8 @@ end function test4
+   (function
+     (function_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (import_statement
+@@ -3021,12 +3096,14 @@ end function test4
+     (end_function_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (function
+     (function_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (import_statement
+@@ -3038,12 +3115,14 @@ end function test4
+     (end_function_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (function
+     (function_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier))
+       (end_of_statement))
+@@ -3053,7 +3132,8 @@ end function test4
+     (whitespace)
+     (variable_declaration
+       (derived_type
+-        (type_name))
++        (type_name
++          (identifier)))
+       (whitespace)
+       (type_qualifier)
+       (whitespace)
+@@ -3063,12 +3143,14 @@ end function test4
+     (end_function_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (function
+     (function_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (import_statement
+@@ -3080,7 +3162,8 @@ end function test4
+     (end_function_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -3099,20 +3182,23 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (whitespace)
+         (identifier))
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)))
+     (end_of_statement)
+@@ -3120,7 +3206,8 @@ END PROGRAM
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (sized_declarator
+           (identifier)
+@@ -3159,7 +3246,8 @@ END PROGRAM
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -3183,13 +3271,15 @@ END PROGRAM
+     (namelist_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (identifier))
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)
+         (identifier)))
+@@ -3218,7 +3308,8 @@ END PROGRAM test
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (enum
+@@ -3270,7 +3361,8 @@ END PROGRAM test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -3302,7 +3394,8 @@ end subroutine print_decorated_numbers
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier))
+       (end_of_statement))
+@@ -3417,7 +3510,8 @@ end subroutine print_decorated_numbers
+           (output_item_list
+             (derived_type_member_expression
+               (identifier)
+-              (type_member))))
++              (type_member
++                (identifier)))))
+         (end_of_statement))
+       (whitespace)
+       (type_statement
+@@ -3439,7 +3533,8 @@ end subroutine print_decorated_numbers
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -3465,7 +3560,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -3529,7 +3625,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -3557,7 +3654,8 @@ end subroutine assumed_rank
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier))
+       (end_of_statement))
+@@ -3645,7 +3743,8 @@ end subroutine assumed_rank
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -3666,7 +3765,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (associate_statement
+@@ -3684,7 +3784,8 @@ end program
+       (end_of_statement)
+       (whitespace)
+       (associate_statement
+-        (block_label_start_expression)
++        (block_label_start_expression
++          (identifier))
+         (association
+           (identifier)
+           (whitespace)
+@@ -3692,7 +3793,8 @@ end program
+           (call_expression
+             (derived_type_member_expression
+               (identifier)
+-              (type_member))
++              (type_member
++                (identifier)))
+             (argument_list)))
+         (end_of_statement)
+         (whitespace)
+@@ -3710,7 +3812,8 @@ end program
+         (end_associate_statement
+           (whitespace)
+           (whitespace)
+-          (block_label)))
++          (block_label
++            (identifier))))
+       (end_of_statement)
+       (whitespace)
+       (end_associate_statement
+@@ -3749,7 +3852,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (interface
+@@ -3764,7 +3868,8 @@ end program
+           (intrinsic_type)
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier))
+           (end_of_statement))
+@@ -3781,7 +3886,8 @@ end program
+         (end_function_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (whitespace)
+       (end_interface_statement
+@@ -3800,7 +3906,8 @@ end program
+           (intrinsic_type)
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (parameters
+             (identifier)
+             (whitespace)
+@@ -3821,7 +3928,8 @@ end program
+         (end_function_statement
+           (whitespace)
+           (whitespace)
+-          (name)
++          (name
++            (identifier))
+           (end_of_statement)))
+       (whitespace)
+       (end_interface_statement
+@@ -3900,13 +4008,15 @@ end module
+   (module
+     (module_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (use_statement
+       (whitespace)
+       (module_name
+-        (name))
++        (name
++          (identifier)))
+       (included_items
+         (whitespace)
+         (whitespace)
+@@ -3945,7 +4055,8 @@ end module
+         (whitespace)
+         (whitespace)
+         (method_name
+-          (name)))
++          (name
++            (identifier))))
+       (whitespace)
+       (end_interface_statement
+         (whitespace)
+@@ -3962,7 +4073,8 @@ end module
+           (whitespace))
+         (whitespace)
+         (method_name
+-          (name)))
++          (name
++            (identifier))))
+       (whitespace)
+       (end_interface_statement
+         (whitespace)
+@@ -3973,7 +4085,8 @@ end module
+     (derived_type_definition
+       (derived_type_statement
+         (whitespace)
+-        (type_name)
++        (type_name
++          (identifier))
+         (end_of_statement))
+       (whitespace)
+       (derived_type_procedures
+@@ -3993,7 +4106,8 @@ end module
+             (whitespace)
+             (whitespace)
+             (method_name
+-              (name))))
++              (name
++                (identifier)))))
+         (whitespace)
+         (comment)
+         (whitespace)
+@@ -4009,12 +4123,14 @@ end module
+             (whitespace)
+             (whitespace)
+             (method_name
+-              (name)))))
++              (name
++                (identifier))))))
+       (whitespace)
+       (end_type_statement
+         (whitespace)
+         (whitespace)
+-        (name)
++        (name
++          (identifier))
+         (end_of_statement)))
+     (end_module_statement
+       (whitespace)
+@@ -4052,7 +4168,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (data_statement
+@@ -4108,7 +4225,8 @@ end program test
+       (data_set
+         (derived_type_member_expression
+           (identifier)
+-          (type_member))
++          (type_member
++            (identifier)))
+         (whitespace)
+         (data_value
+           (whitespace)
+@@ -4260,7 +4378,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -4291,7 +4410,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (file_position_statement
+@@ -4321,7 +4441,8 @@ end program
+       (unit_identifier
+         (derived_type_member_expression
+           (identifier)
+-          (type_member)))
++          (type_member
++            (identifier))))
+       (whitespace)
+       (keyword_argument
+         (identifier)
+@@ -4390,7 +4511,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (inquire_statement
+@@ -4446,7 +4568,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -4475,7 +4598,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (allocate_statement
+@@ -4520,8 +4644,10 @@ end program test
+         (derived_type_member_expression
+           (derived_type_member_expression
+             (identifier)
+-            (type_member))
+-          (type_member))
++            (type_member
++              (identifier)))
++          (type_member
++            (identifier)))
+         (size
+           (number_literal)
+           (whitespace)
+@@ -4539,7 +4665,8 @@ end program test
+             (identifier)
+             (argument_list
+               (identifier)))
+-          (type_member))
++          (type_member
++            (identifier)))
+         (size
+           (identifier)
+           (whitespace)
+@@ -4559,7 +4686,8 @@ end program test
+     (deallocate_statement
+       (derived_type_member_expression
+         (identifier)
+-        (type_member)))
++        (type_member
++          (identifier))))
+     (end_of_statement)
+     (whitespace)
+     (deallocate_statement
+@@ -4587,12 +4715,14 @@ end program test
+     (nullify_statement
+       (derived_type_member_expression
+         (identifier)
+-        (type_member)))
++        (type_member
++          (identifier))))
+     (end_of_statement)
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -4646,7 +4776,8 @@ Statement Functions (Obsolescent)
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (whitespace)
+         (identifier)
+@@ -4741,7 +4872,8 @@ Statement Functions (Obsolescent)
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -4773,7 +4905,8 @@ Entry statement (Obsolescent)
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier)
+         (whitespace)
+@@ -4803,7 +4936,8 @@ Entry statement (Obsolescent)
+     (whitespace)
+     (entry_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier)
+         (whitespace)
+@@ -4817,7 +4951,8 @@ Entry statement (Obsolescent)
+     (whitespace)
+     (entry_statement
+       (whitespace)
+-      (name))
++      (name
++        (identifier)))
+     (end_of_statement)
+     (whitespace)
+     (keyword_statement)
+@@ -4829,14 +4964,16 @@ Entry statement (Obsolescent)
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier))
+       (end_of_statement))
+     (whitespace)
+     (entry_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (parameters
+         (identifier)))
+     (end_of_statement)
+@@ -4850,7 +4987,8 @@ Entry statement (Obsolescent)
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -4870,7 +5008,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -4936,7 +5075,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -4957,7 +5097,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (print_statement
+@@ -5037,7 +5178,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -5061,7 +5203,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (coarray_statement
+@@ -5133,7 +5276,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -5156,7 +5300,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (coarray_statement
+@@ -5182,7 +5327,8 @@ end program test
+       (end_of_statement)
+       (whitespace)
+       (coarray_team_statement
+-        (block_label_start_expression)
++        (block_label_start_expression
++          (identifier))
+         (whitespace)
+         (whitespace)
+         (argument_list
+@@ -5215,7 +5361,8 @@ end program test
+         (end_coarray_team_statement
+           (whitespace)
+           (whitespace)
+-          (block_label)))
++          (block_label
++            (identifier))))
+       (end_of_statement)
+       (whitespace)
+       (end_coarray_team_statement
+@@ -5224,7 +5371,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -5243,7 +5391,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (coarray_critical_statement
+@@ -5265,7 +5414,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -5284,7 +5434,8 @@ end program test;
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (whitespace)
+@@ -5310,7 +5461,8 @@ end program test;
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -5327,7 +5479,8 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -5345,7 +5498,8 @@ end program test
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -5365,7 +5519,8 @@ end subroutine test
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       parameters: (parameters
+         (identifier)
+         (whitespace)
+@@ -5403,7 +5558,8 @@ end subroutine test
+     (whitespace)
+     (variable_declaration
+       type: (derived_type
+-        name: (type_name))
++        name: (type_name
++          (identifier)))
+       (whitespace)
+       (whitespace)
+       declarator: (identifier))
+@@ -5413,7 +5569,8 @@ end subroutine test
+       type: (declared_type
+         name: (derived_type_member_expression
+           (identifier)
+-          (type_member)))
++          (type_member
++            (identifier))))
+       (whitespace)
+       (whitespace)
+       declarator: (identifier))
+@@ -5421,7 +5578,8 @@ end subroutine test
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -5477,7 +5635,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (keyword_statement
+@@ -5517,7 +5676,8 @@ end subroutine pointer_name_clash
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (whitespace)
+       parameters: (parameters
+         (whitespace)
+@@ -5612,12 +5772,14 @@ end subroutine pointer_name_clash
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement)))
+   (subroutine
+     (subroutine_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (variable_declaration
+@@ -5645,7 +5807,8 @@ end subroutine pointer_name_clash
+     (end_subroutine_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))
+ 
+ ================================================================================
+@@ -5665,7 +5828,8 @@ end program
+   (program
+     (program_statement
+       (whitespace)
+-      name: (name)
++      name: (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (implicit_statement
+@@ -5733,13 +5897,15 @@ end program test
+   (program
+     (program_statement
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))
+     (whitespace)
+     (common_statement
+       (whitespace)
+       (variable_group
+-        (name)
++        (name
++          (identifier))
+         (whitespace)
+         (identifier)))
+     (end_of_statement)
+@@ -5756,10 +5922,12 @@ end program test
+         (identifier))
+       (whitespace)
+       (whitespace)
+-      (common_block))
++      (common_block
++        (identifier)))
+     (end_of_statement)
+     (end_program_statement
+       (whitespace)
+       (whitespace)
+-      (name)
++      (name
++        (identifier))
+       (end_of_statement))))

--- a/grammar.js
+++ b/grammar.js
@@ -198,7 +198,7 @@ module.exports = grammar({
       preprocessor('include'),
       field('path', choice(
         $.string_literal,
-        $.identifier,
+        $._identifier,
         $.system_lib_string,
         alias($.preproc_call_expression, $.call_expression),
       )),
@@ -207,7 +207,7 @@ module.exports = grammar({
 
     preproc_def: $ => seq(
       preprocessor('define'),
-      field('name', $.identifier),
+      field('name', $._identifier),
       // HACK: This `optional($.whitespace)` is a workaround to prevent
       // `tree-sitter` from misinterpreting `#define FOO (bar * baz)` as a
       // `preproc_function_def`. For reasons related to how `token.immediate()`
@@ -224,14 +224,14 @@ module.exports = grammar({
 
     preproc_function_def: $ => seq(
       preprocessor('define'),
-      field('name', $.identifier),
+      field('name', $._identifier),
       field('parameters', $.preproc_params),
       field('value', optional($.preproc_arg)),
       $._external_end_of_statement,
     ),
 
     preproc_params: $ => seq(
-      token.immediate('('), commaSep(choice($.identifier, '...')), ')',
+      token.immediate('('), commaSep(choice($._identifier, '...')), ')',
     ),
 
     preproc_call: $ => seq(
@@ -270,7 +270,7 @@ module.exports = grammar({
     preproc_directive: _ => /#[ \t]*[a-zA-Z0-9]\w*/,
 
     _preproc_expression: $ => choice(
-      $.identifier,
+      $._identifier,
       alias($.preproc_call_expression, $.call_expression),
       $.number_literal,
       $.string_literal,
@@ -287,8 +287,8 @@ module.exports = grammar({
     ),
 
     preproc_defined: $ => choice(
-      prec(PREPROC_PREC.CALL, seq('defined', '(', $.identifier, ')')),
-      seq('defined', $.identifier),
+      prec(PREPROC_PREC.CALL, seq('defined', '(', $._identifier, ')')),
+      seq('defined', $._identifier),
     ),
 
     // Preprocessor unary operator uses an external scanner to catch
@@ -299,7 +299,7 @@ module.exports = grammar({
     )),
 
     preproc_call_expression: $ => prec(PREPROC_PREC.CALL, seq(
-      field('function', $.identifier),
+      field('function', $._identifier),
       field('arguments', alias($.preproc_argument_list, $.argument_list)),
     )),
 
@@ -556,7 +556,7 @@ module.exports = grammar({
     language_binding: $ => seq(
       caseInsensitive('bind'),
       '(',
-      $.identifier,
+      $._identifier,
       optional(seq(',', $.keyword_argument)),
       ')'
     ),
@@ -585,11 +585,11 @@ module.exports = grammar({
     function_result: $ => seq(
       caseInsensitive('result'),
       '(',
-      $.identifier,
+      $._identifier,
       ')'
     ),
 
-    _name: $ => alias($.identifier, $.name),
+    _name: $ => alias($._identifier, $.name),
 
     _parameters: $ => choice(
       seq('(', ')'),
@@ -598,7 +598,7 @@ module.exports = grammar({
 
     parameters: $ => seq(
       '(',
-      commaSep1($.identifier),
+      commaSep1($._identifier),
       ')'
     ),
 
@@ -693,15 +693,15 @@ module.exports = grammar({
       optional(commaSep1(
         choice(
           $.use_alias,
-          $.identifier,
+          $._identifier,
           $._generic_procedure)
       ))
     ),
 
     use_alias: $ => seq(
-      alias($.identifier, $.local_name),
+      alias($._identifier, $.local_name),
       '=>',
-      $.identifier
+      $._identifier
     ),
 
     implicit_statement: $ => seq(
@@ -743,8 +743,8 @@ module.exports = grammar({
     _identifier_or_common_block: $ => seq(
       optional('::'),
       commaSep1(choice(
-        $.identifier,
-        seq('/', alias($.identifier, $.common_block), '/'),
+        $._identifier,
+        seq('/', alias($._identifier, $.common_block), '/'),
       )),
     ),
 
@@ -752,7 +752,7 @@ module.exports = grammar({
       caseInsensitive('private'),
       optional(seq(
         optional('::'),
-        commaSep1(choice($.identifier, $._generic_procedure))
+        commaSep1(choice($._identifier, $._generic_procedure))
       )),
     )),
 
@@ -760,7 +760,7 @@ module.exports = grammar({
       caseInsensitive('public'),
       optional(seq(
         optional('::'),
-        commaSep1(choice($.identifier, $._generic_procedure))
+        commaSep1(choice($._identifier, $._generic_procedure))
       )),
     )),
 
@@ -795,10 +795,10 @@ module.exports = grammar({
       optional($._import_names),
     )),
     _import_names: $ => choice(
-      seq(optional('::'), commaSep1($.identifier)),
+      seq(optional('::'), commaSep1($._identifier)),
       seq(',',
           choice(
-            seq(caseInsensitive('only'), ':', commaSep1($.identifier)),
+            seq(caseInsensitive('only'), ':', commaSep1($._identifier)),
             caseInsensitive('none'),
             caseInsensitive('all')
           )
@@ -838,7 +838,7 @@ module.exports = grammar({
 
     base_type_specifier: $ => seq(
       caseInsensitive('extends'),
-      '(', $.identifier, ')'
+      '(', $._identifier, ')'
     ),
 
     // These are only valid to specify once each, but tree-sitter
@@ -868,7 +868,7 @@ module.exports = grammar({
 
     end_type_statement: $ => blockStructureEnding($, 'type'),
 
-    _type_name: $ => alias($.identifier, $.type_name),
+    _type_name: $ => alias($._identifier, $.type_name),
 
     derived_type_procedures: $ => seq(
       $.contains_statement,
@@ -885,7 +885,7 @@ module.exports = grammar({
     procedure_statement: $ => seq(
       $.procedure_kind,
       optional(seq(
-        '(', alias($.identifier, $.procedure_interface), ')'
+        '(', alias($._identifier, $.procedure_interface), ')'
       )),
       optional(seq(
         ',',
@@ -899,7 +899,7 @@ module.exports = grammar({
     ),
     binding: $ => seq($.binding_name, '=>', $.method_name),
     binding_name: $ => choice(
-      $.identifier,
+      $._identifier,
       $._generic_procedure
     ),
     method_name: $ => $._name,
@@ -917,7 +917,7 @@ module.exports = grammar({
       caseInsensitive('deferred'),
       seq(
         caseInsensitive('pass'),
-        optional(seq('(', $.identifier, ')'))
+        optional(seq('(', $._identifier, ')'))
       ),
       caseInsensitive('nopass'),
       caseInsensitive('non_overridable'),
@@ -955,7 +955,7 @@ module.exports = grammar({
         '(',
         optional(
           choice(
-            alias($.identifier, $.procedure_interface),
+            alias($._identifier, $.procedure_interface),
             $.intrinsic_type,
             $.derived_type,
           )
@@ -988,13 +988,13 @@ module.exports = grammar({
     ),
 
     _variable_declarator: $ => choice(
-      $.identifier,
+      $._identifier,
       $.sized_declarator,
       $.coarray_declarator,
     ),
 
     sized_declarator: $ => prec.right(1, seq(
-        $.identifier,
+        $._identifier,
         choice(
           seq(
             alias($.argument_list, $.size),
@@ -1066,7 +1066,7 @@ module.exports = grammar({
       ),
       '(',
       field('name', choice(
-        $.identifier,
+        $._identifier,
         $.derived_type_member_expression,
       )),
       ')'
@@ -1161,7 +1161,7 @@ module.exports = grammar({
       ')',
     )),
 
-    parameter_assignment: $ => seq($.identifier, '=', $._expression),
+    parameter_assignment: $ => seq($._identifier, '=', $._expression),
 
     equivalence_statement: $ => seq(
       caseInsensitive('equivalence'),
@@ -1170,9 +1170,9 @@ module.exports = grammar({
 
     equivalence_set: $ => seq(
       '(',
-      choice($.identifier, $.call_expression),
+      choice($._identifier, $.call_expression),
       ',',
-      commaSep1(choice($.identifier, $.call_expression)),
+      commaSep1(choice($._identifier, $.call_expression)),
       ')'
     ),
 
@@ -1182,7 +1182,7 @@ module.exports = grammar({
     ),
     cray_pointer_pair: $ => seq(
       '(',
-      field('pointer', $.identifier),
+      field('pointer', $._identifier),
       ',',
       field('target', $._variable_declarator),
       ')',
@@ -1288,8 +1288,8 @@ module.exports = grammar({
 
     keyword_statement: $ => choice(
       caseInsensitive('continue'),
-      seq(caseInsensitive('cycle'), optional($.identifier)),
-      seq(caseInsensitive('exit'), optional($.identifier)),
+      seq(caseInsensitive('cycle'), optional($._identifier)),
+      seq(caseInsensitive('exit'), optional($._identifier)),
       seq(
         whiteSpacedKeyword('go', 'to'),
         choice(
@@ -1327,7 +1327,7 @@ module.exports = grammar({
     data_set: $ => prec(1, seq(
       commaSep1(
         choice(
-          $.identifier,
+          $._identifier,
           $.implied_do_loop_expression,
           $.call_expression,  // For array indexing
           $.derived_type_member_expression
@@ -1339,7 +1339,7 @@ module.exports = grammar({
       '/',
       commaSep1(seq(
         optional(prec(1,
-          seq(field('repeat', choice($.number_literal, $.identifier)), '*')
+          seq(field('repeat', choice($.number_literal, $._identifier)), '*')
         )),
         choice(
           $.number_literal,
@@ -1349,7 +1349,7 @@ module.exports = grammar({
           // Only constants allowed here, so can't have general expression as child
           alias($._signed_literal, $.unary_expression),
           $.null_literal,
-          $.identifier,
+          $._identifier,
           $.call_expression
         )
       )),
@@ -1421,7 +1421,7 @@ module.exports = grammar({
     ),
 
     concurrent_control: $ => seq(
-      $.identifier,
+      $._identifier,
       '=',
       field('initial', $._expression),
       ':',
@@ -1439,7 +1439,7 @@ module.exports = grammar({
           caseInsensitive('local_init'),
           caseInsensitive('shared'),
         ),
-        '(', commaSep1($.identifier), ')'
+        '(', commaSep1($._identifier), ')'
       ),
       seq(
         caseInsensitive('default'),
@@ -1447,7 +1447,7 @@ module.exports = grammar({
       ),
       seq(
         caseInsensitive('reduce'),
-        '(', $.binary_op, ':', commaSep1($.identifier), ')',
+        '(', $.binary_op, ':', commaSep1($._identifier), ')',
       ),
     ),
     binary_op: $ => choice('+', '*', /(\.\w+\.|\w+)/),
@@ -1548,7 +1548,7 @@ module.exports = grammar({
     ),
 
     triplet_spec: $ => seq(
-      $.identifier,
+      $._identifier,
       '=',
       $._expression,
       ':',
@@ -1668,7 +1668,7 @@ module.exports = grammar({
             whiteSpacedKeyword('class', 'is')
           ),
           choice(
-            seq('(', field('type', choice($.intrinsic_type, $.identifier)), ')'),
+            seq('(', field('type', choice($.intrinsic_type, $._identifier)), ')'),
           ),
         ),
         $.class_default
@@ -1723,7 +1723,7 @@ module.exports = grammar({
     ),
 
     association: $ => seq(
-      field('name', $.identifier),
+      field('name', $._identifier),
       '=>',
       field('selector', $._expression)
     ),
@@ -1852,7 +1852,7 @@ module.exports = grammar({
       caseInsensitive('enumerator'),
       optional('::'),
       commaSep1(field('declarator', choice(
-        $.identifier,
+        $._identifier,
         alias($._declaration_assignment, $.init_declarator),
       )))
     ),
@@ -1911,7 +1911,7 @@ module.exports = grammar({
     _io_expressions: $ => prec(1, choice(
       '*',
       $.prefixed_string_literal,
-      $.identifier,
+      $._identifier,
       $.derived_type_member_expression,
       $.concatenation_expression,
       $.math_expression,
@@ -1929,12 +1929,12 @@ module.exports = grammar({
       optional(field('type', seq(
         choice(
           $.intrinsic_type,
-          $.identifier,
+          $._identifier,
         ),
         '::'
       ))),
       commaSep1(field('allocation', choice(
-        $.identifier,
+        $._identifier,
         $.derived_type_member_expression,
         $.sized_allocation,
         $.coarray_allocation,
@@ -1960,7 +1960,7 @@ module.exports = grammar({
     deallocate_statement: $ => seq(
       caseInsensitive('deallocate'),
       '(',
-      commaSep1(choice($.identifier, $.derived_type_member_expression)),
+      commaSep1(choice($._identifier, $.derived_type_member_expression)),
       optional(seq(',', commaSep1($.keyword_argument))),
       ')',
     ),
@@ -1968,7 +1968,7 @@ module.exports = grammar({
     nullify_statement: $ => seq(
       caseInsensitive('nullify'),
       '(',
-      commaSep1(choice($.identifier, $.derived_type_member_expression)),
+      commaSep1(choice($._identifier, $.derived_type_member_expression)),
       ')',
     ),
 
@@ -1988,7 +1988,7 @@ module.exports = grammar({
       caseInsensitive('assign'),
       $.number_literal,
       caseInsensitive('to'),
-      $.identifier
+      $._identifier
     ),
 
     // Expressions
@@ -2000,7 +2000,7 @@ module.exports = grammar({
       $.boolean_literal,
       $.array_literal,
       $.null_literal,
-      $.identifier,
+      $._identifier,
       $.derived_type_member_expression,
       $.logical_expression,
       $.relational_expression,
@@ -2012,7 +2012,6 @@ module.exports = grammar({
       $.implied_do_loop_expression,
       $.coarray_expression,
       $.conditional_expression,
-      $.macro_identifier
     ),
 
     parenthesized_expression: $ => seq(
@@ -2024,7 +2023,7 @@ module.exports = grammar({
     derived_type_member_expression: $ => prec.right(PREC.TYPE_MEMBER, seq(
       $._expression,
       '%',
-      alias($.identifier, $.type_member)
+      alias($._identifier, $.type_member)
     )),
 
     logical_expression: $ => {
@@ -2150,7 +2149,7 @@ module.exports = grammar({
 
     // precedence is used to prevent conflict with assignment expression
     keyword_argument: $ => prec(1, seq(
-      field("name",$.identifier),
+      field("name",$._identifier),
       field("equal", '='),
       field("value",choice($._expression, $.assumed_size, $.assumed_shape))
     )),
@@ -2172,11 +2171,11 @@ module.exports = grammar({
 
     assumed_rank: $ => '..',
 
-    block_label_start_expression: $ => seq(alias($.identifier, 'label'), ':'),
-    _block_label: $ => alias($.identifier, $.block_label),
+    block_label_start_expression: $ => seq(alias($._identifier, 'label'), ':'),
+    _block_label: $ => alias($._identifier, $.block_label),
 
     loop_control_expression: $ => seq(
-      $.identifier,
+      $._identifier,
       '=',
       $._expression,
       ',',
@@ -2205,9 +2204,9 @@ module.exports = grammar({
 
     complex_literal: $ => seq(
       '(',
-      choice($.number_literal, $.identifier, $.unary_expression),
+      choice($.number_literal, $._identifier, $.unary_expression),
       ',',
-      choice($.number_literal, $.identifier, $.unary_expression),
+      choice($.number_literal, $._identifier, $.unary_expression),
       ')'
     ),
 
@@ -2243,7 +2242,7 @@ module.exports = grammar({
       caseInsensitive('null'),
       '(',
       optional(field('mold', choice(
-        $.identifier,
+        $._identifier,
         $.derived_type_member_expression,
       ))),
       ')',
@@ -2288,7 +2287,7 @@ module.exports = grammar({
 
     coarray_declarator: $ => prec.right(seq(
       choice(
-        $.identifier,
+        $._identifier,
         $.sized_declarator,
       ),
       alias($.coarray_index, $.coarray_size),
@@ -2451,6 +2450,11 @@ module.exports = grammar({
       caseInsensitive('write', false),
     ),
 
+    _identifier: $ => choice(
+      $.identifier,
+      $.macro_identifier,
+    ),
+
     comment: $ => token(seq('!', /.*/)),
 
     end_of_statement: $ => choice(';', $._external_end_of_statement),
@@ -2565,7 +2569,7 @@ function preprocIf(suffix, content, precedence = 0) {
 
     ['preproc_ifdef' + suffix]: $ => prec(precedence, seq(
       choice(preprocessor('ifdef'), preprocessor('ifndef')),
-      field('name', $.identifier),
+      field('name', $._identifier),
       optional(preprocComment($)),
       field('content', content($)),
       field('alternative', optional(alternativeBlock($))),
@@ -2589,7 +2593,7 @@ function preprocIf(suffix, content, precedence = 0) {
 
     ['preproc_elifdef' + suffix]: $ => prec(precedence, seq(
       choice(preprocessor('elifdef'), preprocessor('elifndef')),
-      field('name', $.identifier),
+      field('name', $._identifier),
       optional(preprocComment($)),
       field('content', content($)),
       field('alternative', optional(alternativeBlock($))),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -271,7 +271,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "identifier"
+                "name": "_identifier"
               },
               {
                 "type": "SYMBOL",
@@ -312,7 +312,7 @@
           "name": "name",
           "content": {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           }
         },
         {
@@ -366,7 +366,7 @@
           "name": "name",
           "content": {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           }
         },
         {
@@ -420,7 +420,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "identifier"
+                      "name": "_identifier"
                     },
                     {
                       "type": "STRING",
@@ -442,7 +442,7 @@
                         "members": [
                           {
                             "type": "SYMBOL",
-                            "name": "identifier"
+                            "name": "_identifier"
                           },
                           {
                             "type": "STRING",
@@ -650,7 +650,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -918,7 +918,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -1168,7 +1168,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -1517,7 +1517,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -1806,7 +1806,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -2176,7 +2176,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -2465,7 +2465,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -2814,7 +2814,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -3096,7 +3096,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -3445,7 +3445,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -3710,7 +3710,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -4008,7 +4008,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -4256,7 +4256,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -4554,7 +4554,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -4802,7 +4802,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -5100,7 +5100,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -5348,7 +5348,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -5646,7 +5646,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -5891,7 +5891,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -6180,7 +6180,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -6422,7 +6422,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -6711,7 +6711,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -6953,7 +6953,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -7242,7 +7242,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -7341,7 +7341,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "ALIAS",
@@ -7429,7 +7429,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "identifier"
+                "name": "_identifier"
               },
               {
                 "type": "STRING",
@@ -7447,7 +7447,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           ]
         }
@@ -7489,7 +7489,7 @@
             "name": "function",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -9849,7 +9849,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "CHOICE",
@@ -10127,7 +10127,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "STRING",
@@ -10139,7 +10139,7 @@
       "type": "ALIAS",
       "content": {
         "type": "SYMBOL",
-        "name": "identifier"
+        "name": "_identifier"
       },
       "named": true,
       "value": "name"
@@ -10178,7 +10178,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             },
             {
               "type": "REPEAT",
@@ -10191,7 +10191,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "_identifier"
                   }
                 ]
               }
@@ -10631,7 +10631,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "identifier"
+                      "name": "_identifier"
                     },
                     {
                       "type": "SYMBOL",
@@ -10657,7 +10657,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "identifier"
+                            "name": "_identifier"
                           },
                           {
                             "type": "SYMBOL",
@@ -10684,7 +10684,7 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           },
           "named": true,
           "value": "local_name"
@@ -10695,7 +10695,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         }
       ]
     },
@@ -11001,7 +11001,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_identifier"
                 },
                 {
                   "type": "SEQ",
@@ -11014,7 +11014,7 @@
                       "type": "ALIAS",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       },
                       "named": true,
                       "value": "common_block"
@@ -11041,7 +11041,7 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       },
                       {
                         "type": "SEQ",
@@ -11054,7 +11054,7 @@
                             "type": "ALIAS",
                             "content": {
                               "type": "SYMBOL",
-                              "name": "identifier"
+                              "name": "_identifier"
                             },
                             "named": true,
                             "value": "common_block"
@@ -11115,7 +11115,7 @@
                         "members": [
                           {
                             "type": "SYMBOL",
-                            "name": "identifier"
+                            "name": "_identifier"
                           },
                           {
                             "type": "SYMBOL",
@@ -11137,7 +11137,7 @@
                               "members": [
                                 {
                                   "type": "SYMBOL",
-                                  "name": "identifier"
+                                  "name": "_identifier"
                                 },
                                 {
                                   "type": "SYMBOL",
@@ -11201,7 +11201,7 @@
                         "members": [
                           {
                             "type": "SYMBOL",
-                            "name": "identifier"
+                            "name": "_identifier"
                           },
                           {
                             "type": "SYMBOL",
@@ -11223,7 +11223,7 @@
                               "members": [
                                 {
                                   "type": "SYMBOL",
-                                  "name": "identifier"
+                                  "name": "_identifier"
                                 },
                                 {
                                   "type": "SYMBOL",
@@ -11447,7 +11447,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_identifier"
                 },
                 {
                   "type": "REPEAT",
@@ -11460,7 +11460,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       }
                     ]
                   }
@@ -11500,7 +11500,7 @@
                       "members": [
                         {
                           "type": "SYMBOL",
-                          "name": "identifier"
+                          "name": "_identifier"
                         },
                         {
                           "type": "REPEAT",
@@ -11513,7 +11513,7 @@
                               },
                               {
                                 "type": "SYMBOL",
-                                "name": "identifier"
+                                "name": "_identifier"
                               }
                             ]
                           }
@@ -11711,7 +11711,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "STRING",
@@ -11945,7 +11945,7 @@
       "type": "ALIAS",
       "content": {
         "type": "SYMBOL",
-        "name": "identifier"
+        "name": "_identifier"
       },
       "named": true,
       "value": "type_name"
@@ -12022,7 +12022,7 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "_identifier"
                   },
                   "named": true,
                   "value": "procedure_interface"
@@ -12167,7 +12167,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "SYMBOL",
@@ -12291,7 +12291,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       },
                       {
                         "type": "STRING",
@@ -12518,7 +12518,7 @@
                           "type": "ALIAS",
                           "content": {
                             "type": "SYMBOL",
-                            "name": "identifier"
+                            "name": "_identifier"
                           },
                           "named": true,
                           "value": "procedure_interface"
@@ -12750,7 +12750,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "SYMBOL",
@@ -12770,7 +12770,7 @@
         "members": [
           {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           },
           {
             "type": "CHOICE",
@@ -13256,7 +13256,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "identifier"
+                "name": "_identifier"
               },
               {
                 "type": "SYMBOL",
@@ -13916,7 +13916,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "STRING",
@@ -13979,7 +13979,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             },
             {
               "type": "SYMBOL",
@@ -13999,7 +13999,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_identifier"
                 },
                 {
                   "type": "SYMBOL",
@@ -14021,7 +14021,7 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       },
                       {
                         "type": "SYMBOL",
@@ -14091,7 +14091,7 @@
           "name": "pointer",
           "content": {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           }
         },
         {
@@ -14604,7 +14604,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_identifier"
                 },
                 {
                   "type": "BLANK"
@@ -14630,7 +14630,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_identifier"
                 },
                 {
                   "type": "BLANK"
@@ -14918,7 +14918,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "_identifier"
                   },
                   {
                     "type": "SYMBOL",
@@ -14948,7 +14948,7 @@
                       "members": [
                         {
                           "type": "SYMBOL",
-                          "name": "identifier"
+                          "name": "_identifier"
                         },
                         {
                           "type": "SYMBOL",
@@ -15010,7 +15010,7 @@
                                 },
                                 {
                                   "type": "SYMBOL",
-                                  "name": "identifier"
+                                  "name": "_identifier"
                                 }
                               ]
                             }
@@ -15061,7 +15061,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "identifier"
+                      "name": "_identifier"
                     },
                     {
                       "type": "SYMBOL",
@@ -15104,7 +15104,7 @@
                                       },
                                       {
                                         "type": "SYMBOL",
-                                        "name": "identifier"
+                                        "name": "_identifier"
                                       }
                                     ]
                                   }
@@ -15155,7 +15155,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "identifier"
+                            "name": "_identifier"
                           },
                           {
                             "type": "SYMBOL",
@@ -15576,7 +15576,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "STRING",
@@ -15676,7 +15676,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_identifier"
                 },
                 {
                   "type": "REPEAT",
@@ -15689,7 +15689,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       }
                     ]
                   }
@@ -15762,7 +15762,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_identifier"
                 },
                 {
                   "type": "REPEAT",
@@ -15775,7 +15775,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       }
                     ]
                   }
@@ -16390,7 +16390,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "STRING",
@@ -17253,7 +17253,7 @@
                               },
                               {
                                 "type": "SYMBOL",
-                                "name": "identifier"
+                                "name": "_identifier"
                               }
                             ]
                           }
@@ -17635,7 +17635,7 @@
           "name": "name",
           "content": {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           }
         },
         {
@@ -18475,7 +18475,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "_identifier"
                   },
                   {
                     "type": "ALIAS",
@@ -18506,7 +18506,7 @@
                       "members": [
                         {
                           "type": "SYMBOL",
-                          "name": "identifier"
+                          "name": "_identifier"
                         },
                         {
                           "type": "ALIAS",
@@ -18899,7 +18899,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           },
           {
             "type": "SYMBOL",
@@ -19016,7 +19016,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       }
                     ]
                   },
@@ -19043,7 +19043,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "_identifier"
                   },
                   {
                     "type": "SYMBOL",
@@ -19077,7 +19077,7 @@
                       "members": [
                         {
                           "type": "SYMBOL",
-                          "name": "identifier"
+                          "name": "_identifier"
                         },
                         {
                           "type": "SYMBOL",
@@ -19220,7 +19220,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_identifier"
                 },
                 {
                   "type": "SYMBOL",
@@ -19242,7 +19242,7 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       },
                       {
                         "type": "SYMBOL",
@@ -19327,7 +19327,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "identifier"
+                  "name": "_identifier"
                 },
                 {
                   "type": "SYMBOL",
@@ -19349,7 +19349,7 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "identifier"
+                        "name": "_identifier"
                       },
                       {
                         "type": "SYMBOL",
@@ -19457,7 +19457,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         }
       ]
     },
@@ -19490,7 +19490,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "SYMBOL",
@@ -19535,10 +19535,6 @@
         {
           "type": "SYMBOL",
           "name": "conditional_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "macro_identifier"
         }
       ]
     },
@@ -19577,7 +19573,7 @@
             "type": "ALIAS",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             },
             "named": true,
             "value": "type_member"
@@ -20697,7 +20693,7 @@
             "name": "name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             }
           },
           {
@@ -20844,7 +20840,7 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           },
           "named": false,
           "value": "label"
@@ -20859,7 +20855,7 @@
       "type": "ALIAS",
       "content": {
         "type": "SYMBOL",
-        "name": "identifier"
+        "name": "_identifier"
       },
       "named": true,
       "value": "block_label"
@@ -20869,7 +20865,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "STRING",
@@ -21054,7 +21050,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             },
             {
               "type": "SYMBOL",
@@ -21075,7 +21071,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             },
             {
               "type": "SYMBOL",
@@ -21238,7 +21234,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "identifier"
+                      "name": "_identifier"
                     },
                     {
                       "type": "SYMBOL",
@@ -21514,7 +21510,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "identifier"
+                "name": "_identifier"
               },
               {
                 "type": "SYMBOL",
@@ -22369,6 +22365,19 @@
         {
           "type": "PATTERN",
           "value": "[wW][rR][iI][tT][eE]"
+        }
+      ]
+    },
+    "_identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "macro_identifier"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -378,6 +378,10 @@
             "named": true
           },
           {
+            "type": "macro_identifier",
+            "named": true
+          },
+          {
             "type": "sized_allocation",
             "named": true
           }
@@ -397,6 +401,10 @@
           },
           {
             "type": "intrinsic_type",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           }
         ]
@@ -510,6 +518,10 @@
           "named": true
         },
         {
+          "type": "macro_identifier",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         }
@@ -617,6 +629,10 @@
           {
             "type": "identifier",
             "named": true
+          },
+          {
+            "type": "macro_identifier",
+            "named": true
           }
         ]
       },
@@ -653,6 +669,10 @@
         {
           "type": "identifier",
           "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
         }
       ]
     }
@@ -675,6 +695,10 @@
           },
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           },
           {
@@ -794,6 +818,10 @@
             "named": true
           },
           {
+            "type": "macro_identifier",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -841,6 +869,10 @@
         {
           "type": "language_binding",
           "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
         }
       ]
     }
@@ -882,6 +914,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         },
         {
@@ -1192,7 +1228,21 @@
   {
     "type": "block_label",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "block_label_start_expression",
@@ -1302,6 +1352,10 @@
         "types": [
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           }
         ]
@@ -1524,6 +1578,10 @@
           "named": true
         },
         {
+          "type": "macro_identifier",
+          "named": true
+        },
+        {
           "type": "sized_declarator",
           "named": true
         }
@@ -1672,7 +1730,21 @@
   {
     "type": "common_block",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "common_statement",
@@ -1688,6 +1760,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         },
         {
@@ -1711,6 +1787,10 @@
       "types": [
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         },
         {
@@ -1802,6 +1882,10 @@
         {
           "type": "identifier",
           "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
         }
       ]
     }
@@ -1850,6 +1934,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         }
       ]
@@ -1949,6 +2037,10 @@
           {
             "type": "identifier",
             "named": true
+          },
+          {
+            "type": "macro_identifier",
+            "named": true
           }
         ]
       },
@@ -1962,6 +2054,10 @@
           },
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           },
           {
@@ -2001,6 +2097,10 @@
           },
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           },
           {
@@ -2048,6 +2148,10 @@
         {
           "type": "implied_do_loop_expression",
           "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
         }
       ]
     }
@@ -2080,6 +2184,10 @@
             "named": true
           },
           {
+            "type": "macro_identifier",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           }
@@ -2104,6 +2212,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         },
         {
@@ -2144,6 +2256,10 @@
         {
           "type": "keyword_argument",
           "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
         }
       ]
     }
@@ -2162,6 +2278,10 @@
           },
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           }
         ]
@@ -3202,6 +3322,10 @@
           {
             "type": "init_declarator",
             "named": true
+          },
+          {
+            "type": "macro_identifier",
+            "named": true
           }
         ]
       }
@@ -3221,6 +3345,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         }
       ]
@@ -3324,6 +3452,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         },
         {
@@ -3441,6 +3573,10 @@
       "types": [
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         }
       ]
@@ -3627,6 +3763,10 @@
         {
           "type": "identifier",
           "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
         }
       ]
     }
@@ -3668,6 +3808,10 @@
           "named": true
         },
         {
+          "type": "macro_identifier",
+          "named": true
+        },
+        {
           "type": "operator",
           "named": true
         },
@@ -3692,6 +3836,10 @@
           },
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           },
           {
@@ -4020,6 +4168,10 @@
           {
             "type": "identifier",
             "named": true
+          },
+          {
+            "type": "macro_identifier",
+            "named": true
           }
         ]
       },
@@ -4084,7 +4236,21 @@
   {
     "type": "label",
     "named": false,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "language_binding",
@@ -4101,6 +4267,10 @@
         {
           "type": "keyword_argument",
           "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
         }
       ]
     }
@@ -4108,7 +4278,21 @@
   {
     "type": "local_name",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "logical_expression",
@@ -4522,7 +4706,21 @@
   {
     "type": "name",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "namelist_statement",
@@ -4559,6 +4757,10 @@
           {
             "type": "identifier",
             "named": true
+          },
+          {
+            "type": "macro_identifier",
+            "named": true
           }
         ]
       }
@@ -4578,6 +4780,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         }
       ]
@@ -4701,6 +4907,10 @@
         {
           "type": "identifier",
           "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
         }
       ]
     }
@@ -4761,6 +4971,10 @@
           },
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           },
           {
@@ -4848,6 +5062,10 @@
           {
             "type": "identifier",
             "named": true
+          },
+          {
+            "type": "macro_identifier",
+            "named": true
           }
         ]
       },
@@ -4883,6 +5101,10 @@
       "types": [
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         }
       ]
@@ -4924,6 +5146,10 @@
           },
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           },
           {
@@ -5205,6 +5431,10 @@
           {
             "type": "identifier",
             "named": true
+          },
+          {
+            "type": "macro_identifier",
+            "named": true
           }
         ]
       }
@@ -5361,6 +5591,10 @@
           {
             "type": "identifier",
             "named": true
+          },
+          {
+            "type": "macro_identifier",
+            "named": true
           }
         ]
       },
@@ -5422,6 +5656,10 @@
           },
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           },
           {
@@ -5703,6 +5941,10 @@
           {
             "type": "identifier",
             "named": true
+          },
+          {
+            "type": "macro_identifier",
+            "named": true
           }
         ]
       }
@@ -5739,6 +5981,10 @@
             "named": true
           },
           {
+            "type": "macro_identifier",
+            "named": true
+          },
+          {
             "type": "string_literal",
             "named": true
           },
@@ -5760,6 +6006,10 @@
       "types": [
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         }
       ]
@@ -5802,6 +6052,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         },
         {
@@ -5849,6 +6103,10 @@
         {
           "type": "identifier",
           "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
         }
       ]
     }
@@ -5861,7 +6119,21 @@
   {
     "type": "procedure_interface",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "procedure_kind",
@@ -6026,6 +6298,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         },
         {
@@ -6211,6 +6487,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         }
       ]
@@ -6464,6 +6744,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         },
         {
@@ -6915,12 +7199,40 @@
   {
     "type": "type_member",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "type_name",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "type_qualifier",
@@ -6970,6 +7282,10 @@
           },
           {
             "type": "intrinsic_type",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           }
         ]
@@ -7107,6 +7423,10 @@
           "named": true
         },
         {
+          "type": "macro_identifier",
+          "named": true
+        },
+        {
           "type": "math_expression",
           "named": true
         },
@@ -7144,6 +7464,10 @@
         },
         {
           "type": "local_name",
+          "named": true
+        },
+        {
+          "type": "macro_identifier",
           "named": true
         }
       ]
@@ -7231,6 +7555,10 @@
             "named": true
           },
           {
+            "type": "macro_identifier",
+            "named": true
+          },
+          {
             "type": "pointer_init_declarator",
             "named": true
           },
@@ -7285,6 +7613,10 @@
           "named": true
         },
         {
+          "type": "macro_identifier",
+          "named": true
+        },
+        {
           "type": "name",
           "named": true
         },
@@ -7309,6 +7641,10 @@
           },
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "macro_identifier",
             "named": true
           },
           {

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -14,7 +14,8 @@ END PROGRAM TEST
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (end_program_statement
       (whitespace)
@@ -22,12 +23,14 @@ END PROGRAM TEST
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -83,7 +86,8 @@ end module
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (private_statement)
@@ -92,13 +96,15 @@ end module
     (use_statement
       (whitespace)
       (module_name
-        (name)))
+        (name
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (interface
       (interface_statement
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (procedure_statement
@@ -106,14 +112,16 @@ end module
           (whitespace))
         (whitespace)
         (method_name
-          (name)))
+          (name
+            (identifier))))
       (whitespace)
       (procedure_statement
         (procedure_kind
           (whitespace))
         (whitespace)
         (method_name
-          (name)))
+          (name
+            (identifier))))
       (whitespace)
       (end_interface_statement
         (whitespace)
@@ -234,7 +242,8 @@ end module
       (function
         (function_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier)
             (whitespace)
@@ -262,7 +271,8 @@ end module
       (function
         (function_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier)
             (whitespace)
@@ -315,7 +325,8 @@ end interface
     (subroutine
       (subroutine_statement
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (parameters
           (identifier)
           (identifier)
@@ -349,13 +360,15 @@ end interface
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (whitespace)
     (function
       (function_statement
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (parameters
           (identifier)
           (identifier))
@@ -385,7 +398,8 @@ end interface
       (end_function_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (end_interface_statement
       (whitespace)
@@ -420,7 +434,8 @@ end interface
     (subroutine
       (subroutine_statement
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (parameters
           (identifier)
           (identifier)
@@ -454,13 +469,15 @@ end interface
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (whitespace)
     (function
       (function_statement
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (parameters
           (identifier)
           (identifier))
@@ -490,7 +507,8 @@ end interface
       (end_function_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (end_interface_statement
       (whitespace)
@@ -511,7 +529,8 @@ end interface
   (interface
     (interface_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (procedure_statement
@@ -519,14 +538,16 @@ end interface
         (whitespace))
       (whitespace)
       (method_name
-        (name)))
+        (name
+          (identifier))))
     (whitespace)
     (procedure_statement
       (procedure_kind
         (whitespace))
       (whitespace)
       (method_name
-        (name)))
+        (name
+          (identifier))))
     (end_interface_statement
       (whitespace)
       (end_of_statement))))
@@ -564,14 +585,16 @@ end interface operator (.not.)
         (whitespace))
       (whitespace)
       (method_name
-        (name)))
+        (name
+          (identifier))))
     (whitespace)
     (procedure_statement
       (procedure_kind
         (whitespace))
       (whitespace)
       (method_name
-        (name)))
+        (name
+          (identifier))))
     (end_interface_statement
       (whitespace)
       (whitespace)
@@ -592,12 +615,14 @@ end interface operator (.not.)
         (whitespace))
       (whitespace)
       (method_name
-        (name)))
+        (name
+          (identifier))))
     (whitespace)
     (function
       (function_statement
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (parameters
           (identifier))
         (end_of_statement))
@@ -651,7 +676,8 @@ end interface assignment (=)
         (whitespace))
       (whitespace)
       (method_name
-        (name)))
+        (name
+          (identifier))))
     (end_interface_statement
       (whitespace)
       (whitespace)
@@ -681,7 +707,8 @@ interface operator(+) ; module procedure test_plus ; end interface
         (whitespace))
       (whitespace)
       (method_name
-        (name)))
+        (name
+          (identifier))))
     (whitespace)
     (whitespace)
     (end_interface_statement
@@ -704,13 +731,15 @@ end module
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (included_items
         (whitespace)
         (whitespace)
@@ -779,7 +808,8 @@ END SUBROUTINE
       (procedure_qualifier)
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier))
       (end_of_statement))
@@ -817,12 +847,14 @@ END SUBROUTINE
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement)))
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (end_subroutine_statement
       (whitespace)
@@ -830,7 +862,8 @@ END SUBROUTINE
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier)
         (whitespace)
@@ -845,7 +878,8 @@ END SUBROUTINE
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (whitespace)
       (language_binding
         (identifier)
@@ -861,7 +895,8 @@ END SUBROUTINE
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -888,7 +923,8 @@ END SUBROUTINE
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier)
             (whitespace)
@@ -989,7 +1025,8 @@ end function
           (number_literal)))
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (comment)
@@ -997,7 +1034,8 @@ end function
     (use_statement
       (whitespace)
       (module_name
-        (name)))
+        (name
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (assignment_statement
@@ -1014,17 +1052,20 @@ end function
   (function
     (function_statement
       (derived_type
-        (type_name))
+        (type_name
+          (identifier)))
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (comment)
     (whitespace)
     (variable_declaration
       (derived_type
-        (type_name))
+        (type_name
+          (identifier)))
       (whitespace)
       (whitespace)
       (identifier))
@@ -1033,7 +1074,8 @@ end function
     (assignment_statement
       (derived_type_member_expression
         (identifier)
-        (type_member))
+        (type_member
+          (identifier)))
       (whitespace)
       (whitespace)
       (number_literal))
@@ -1055,7 +1097,8 @@ end function
           (number_literal)))
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier)
         (whitespace)
@@ -1074,7 +1117,8 @@ end function
           (number_literal)))
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (whitespace)
       (language_binding
         (identifier)
@@ -1090,7 +1134,8 @@ end function
   (function
     (function_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (whitespace)
       (function_result
         (identifier))
@@ -1109,7 +1154,8 @@ end function
   (function
     (function_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (whitespace)
       (language_binding
         (identifier)
@@ -1163,7 +1209,8 @@ end function test
       (intrinsic_type)
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier)
         (whitespace)
@@ -1210,7 +1257,8 @@ end function test
           (procedure_qualifier)
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (whitespace)
           (function_result
             (identifier))
@@ -1235,7 +1283,8 @@ end function test
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier))
           (end_of_statement))
@@ -1271,14 +1320,16 @@ end function test
           (procedure_qualifier)
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier))
           (end_of_statement))
         (whitespace)
         (variable_declaration
           (derived_type
-            (type_name))
+            (type_name
+              (identifier)))
           (whitespace)
           (whitespace)
           (identifier))
@@ -1287,12 +1338,14 @@ end function test
         (end_function_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))))
     (end_function_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1334,13 +1387,15 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (derived_type_definition
       (derived_type_statement
         (whitespace)
-        (type_name)
+        (type_name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (end_type_statement
@@ -1353,7 +1408,8 @@ end program
         (access_specifier)
         (whitespace)
         (whitespace)
-        (type_name)
+        (type_name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (end_of_statement)
@@ -1427,7 +1483,8 @@ end program
           (whitespace)
           (whitespace)
           (method_name
-            (name)))
+            (name
+              (identifier))))
         (whitespace)
         (comment)
         (whitespace)
@@ -1435,7 +1492,8 @@ end program
           (procedure_kind)
           (whitespace)
           (method_name
-            (name)))
+            (name
+              (identifier))))
         (whitespace)
         (comment)
         (whitespace)
@@ -1449,7 +1507,8 @@ end program
           (whitespace)
           (whitespace)
           (method_name
-            (name)))
+            (name
+              (identifier))))
         (whitespace)
         (procedure_statement
           (procedure_kind)
@@ -1463,10 +1522,12 @@ end program
             (whitespace)
             (whitespace)
             (method_name
-              (name)))
+              (name
+                (identifier))))
           (whitespace)
           (method_name
-            (name)))
+            (name
+              (identifier))))
         (whitespace)
         (procedure_statement
           (procedure_kind)
@@ -1480,7 +1541,8 @@ end program
             (whitespace)
             (whitespace)
             (method_name
-              (name))))
+              (name
+                (identifier)))))
         (whitespace)
         (procedure_statement
           (procedure_kind)
@@ -1495,14 +1557,16 @@ end program
             (whitespace)
             (whitespace)
             (method_name
-              (name))))
+              (name
+                (identifier)))))
         (whitespace)
         (procedure_statement
           (procedure_kind)
           (whitespace)
           (whitespace)
           (method_name
-            (name))
+            (name
+              (identifier)))
           (whitespace)
           (binding
             (binding_name
@@ -1510,19 +1574,22 @@ end program
             (whitespace)
             (whitespace)
             (method_name
-              (name))))
+              (name
+                (identifier)))))
         (whitespace)
         (procedure_statement
           (procedure_kind)
           (whitespace)
           (whitespace)
           (method_name
-            (name))))
+            (name
+              (identifier)))))
       (whitespace)
       (end_type_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (whitespace)
     (derived_type_definition
@@ -1531,7 +1598,8 @@ end program
         (abstract_specifier)
         (whitespace)
         (whitespace)
-        (type_name)
+        (type_name
+          (identifier))
         (derived_type_parameter_list
           (identifier)
           (whitespace)
@@ -1608,7 +1676,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (derived_type_definition
@@ -1619,13 +1688,15 @@ end program
         (abstract_specifier)
         (whitespace)
         (whitespace)
-        name: (type_name)
+        name: (type_name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (end_type_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (whitespace)
     (derived_type_definition
@@ -1637,13 +1708,15 @@ end program
           (identifier))
         (whitespace)
         (whitespace)
-        name: (type_name)
+        name: (type_name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (end_type_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (end_program_statement
       (whitespace)
@@ -1670,13 +1743,15 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (derived_type_definition
       (derived_type_statement
         (whitespace)
-        (type_name)
+        (type_name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (derived_type_procedures
@@ -1684,13 +1759,15 @@ end program
         (whitespace)
         (procedure_statement
           (procedure_kind)
-          (procedure_interface)
+          (procedure_interface
+            (identifier))
           (whitespace)
           (procedure_attribute)
           (whitespace)
           (whitespace)
           (method_name
-            (name))))
+            (name
+              (identifier)))))
       (whitespace)
       (end_type_statement
         (whitespace)
@@ -1705,7 +1782,8 @@ end program
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))
         (whitespace)
         (end_subroutine_statement
@@ -1738,13 +1816,15 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (derived_type_definition
       (derived_type_statement
         (whitespace)
-        (type_name)
+        (type_name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (derived_type_procedures
@@ -1757,7 +1837,8 @@ end program test
           (whitespace)
           (whitespace)
           (method_name
-            (name)))
+            (name
+              (identifier))))
         (whitespace)
         (procedure_statement
           (procedure_kind)
@@ -1766,17 +1847,20 @@ end program test
           (whitespace)
           (whitespace)
           (method_name
-            (name))))
+            (name
+              (identifier)))))
       (whitespace)
       (end_type_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1796,18 +1880,21 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (derived_type_definition
       (derived_type_statement
         (whitespace)
-        (type_name)
+        (type_name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (variable_declaration
         (procedure
-          (procedure_interface)
+          (procedure_interface
+            (identifier))
           (whitespace)
           (procedure_attribute))
         (whitespace)
@@ -1828,7 +1915,8 @@ end program test
       (whitespace)
       (variable_declaration
         (procedure
-          (procedure_interface)
+          (procedure_interface
+            (identifier))
           (whitespace)
           (procedure_attribute)
           (whitespace)
@@ -1841,12 +1929,14 @@ end program test
       (end_type_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1871,9 +1961,11 @@ END SUBMODULE ConstructorMethods_child
   (submodule
     (submodule_statement
       (module_name
-        (name))
+        (name
+          (identifier)))
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (implicit_statement
       (whitespace)
@@ -1885,16 +1977,20 @@ END SUBMODULE ConstructorMethods_child
     (end_submodule_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement)))
   (submodule
     (submodule_statement
       (module_name
-        (name))
+        (name
+          (identifier)))
       (module_name
-        (name))
+        (name
+          (identifier)))
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (implicit_statement
       (whitespace)
@@ -1906,7 +2002,8 @@ END SUBMODULE ConstructorMethods_child
     (end_submodule_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1937,7 +2034,8 @@ END MODULE BoundingBox_Method
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (private_statement)
     (end_of_statement)
@@ -1952,7 +2050,8 @@ END MODULE BoundingBox_Method
           (procedure_qualifier)
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier)
             (whitespace)
@@ -1963,7 +2062,8 @@ END MODULE BoundingBox_Method
         (whitespace)
         (variable_declaration
           (derived_type
-            (type_name))
+            (type_name
+              (identifier)))
           (whitespace)
           (type_qualifier)
           (whitespace)
@@ -1974,7 +2074,8 @@ END MODULE BoundingBox_Method
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (end_interface_statement
         (whitespace)
@@ -1988,7 +2089,8 @@ END MODULE BoundingBox_Method
           (procedure_qualifier)
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier))
           (whitespace)
@@ -1998,7 +2100,8 @@ END MODULE BoundingBox_Method
         (whitespace)
         (variable_declaration
           (derived_type
-            (type_name))
+            (type_name
+              (identifier)))
           (whitespace)
           (type_qualifier)
           (whitespace)
@@ -2009,7 +2112,8 @@ END MODULE BoundingBox_Method
         (end_function_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (end_interface_statement
         (whitespace)
@@ -2017,7 +2121,8 @@ END MODULE BoundingBox_Method
     (end_module_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -2044,7 +2149,8 @@ end module test
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (interface
@@ -2056,13 +2162,15 @@ end module test
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))
         (whitespace)
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (whitespace)
       (end_interface_statement
@@ -2075,7 +2183,8 @@ end module test
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier)
             (whitespace)
@@ -2086,7 +2195,8 @@ end module test
         (whitespace)
         (variable_declaration
           (procedure
-            (procedure_interface))
+            (procedure_interface
+              (identifier)))
           (whitespace)
           (whitespace)
           (identifier))
@@ -2094,7 +2204,8 @@ end module test
         (whitespace)
         (variable_declaration
           (procedure
-            (procedure_interface))
+            (procedure_interface
+              (identifier)))
           (whitespace)
           (type_qualifier)
           (whitespace)
@@ -2125,12 +2236,14 @@ end module test
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))))
     (end_module_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -2161,7 +2274,8 @@ end program block_demo
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (implicit_statement
@@ -2216,7 +2330,8 @@ end program block_demo
       (end_of_statement)
       (whitespace)
       (block_construct
-        (block_label_start_expression)
+        (block_label_start_expression
+          (identifier))
         (whitespace)
         (end_of_statement)
         (whitespace)
@@ -2241,7 +2356,8 @@ end program block_demo
         (end_block_construct_statement
           (whitespace)
           (whitespace)
-          (block_label)))
+          (block_label
+            (identifier))))
       (end_of_statement)
       (whitespace)
       (end_block_construct_statement
@@ -2257,7 +2373,8 @@ end program block_demo
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -2277,7 +2394,8 @@ end module enumeration_mod
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (enumeration_type
@@ -2287,7 +2405,8 @@ end module enumeration_mod
         (access_specifier)
         (whitespace)
         (whitespace)
-        (type_name))
+        (type_name
+          (identifier)))
       (whitespace)
       (enumerator_statement
         (whitespace)
@@ -2306,12 +2425,14 @@ end module enumeration_mod
         (whitespace)
         (whitespace)
         (whitespace)
-        (name)))
+        (name
+          (identifier))))
     (end_of_statement)
     (end_module_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -2376,13 +2497,15 @@ Block Data (Obsolescent)
     (block_data_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (whitespace)
@@ -2407,13 +2530,15 @@ Block Data (Obsolescent)
     (block_data_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (whitespace)
@@ -2440,76 +2565,15 @@ Block Data (Obsolescent)
     (block_data_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
-        (whitespace)
-        (identifier)
-        (whitespace)
-        (identifier)
-        (whitespace)
-        (identifier)))
-    (end_of_statement)
-    (whitespace)
-    (data_statement
-      (whitespace)
-      (data_set
-        (identifier)
-        (whitespace)
-        (data_value
-          (number_literal))))
-    (end_of_statement)
-    (whitespace)
-    (end_block_data_statement
-      (whitespace)
-      (end_of_statement)))
-  (whitespace)
-  (block_data
-    (block_data_statement
-      (whitespace)
-      (whitespace)
-      (name)
-      (end_of_statement))
-    (whitespace)
-    (common_statement
-      (whitespace)
-      (variable_group
-        (name)
-        (whitespace)
-        (identifier)
-        (whitespace)
-        (identifier)
-        (whitespace)
-        (identifier)))
-    (end_of_statement)
-    (whitespace)
-    (data_statement
-      (whitespace)
-      (data_set
-        (identifier)
-        (whitespace)
-        (data_value
-          (number_literal))))
-    (end_of_statement)
-    (whitespace)
-    (end_block_data_statement
-      (end_of_statement)))
-  (whitespace)
-  (block_data
-    (block_data_statement
-      (whitespace)
-      (whitespace)
-      (name)
-      (end_of_statement))
-    (whitespace)
-    (common_statement
-      (whitespace)
-      (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (whitespace)
@@ -2535,13 +2599,15 @@ Block Data (Obsolescent)
     (block_data_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (whitespace)
@@ -2560,21 +2626,21 @@ Block Data (Obsolescent)
     (end_of_statement)
     (whitespace)
     (end_block_data_statement
-      (whitespace)
-      (name)
       (end_of_statement)))
   (whitespace)
   (block_data
     (block_data_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (whitespace)
@@ -2594,22 +2660,21 @@ Block Data (Obsolescent)
     (whitespace)
     (end_block_data_statement
       (whitespace)
-      (whitespace)
-      (whitespace)
-      (name)
       (end_of_statement)))
   (whitespace)
   (block_data
     (block_data_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (whitespace)
@@ -2629,21 +2694,23 @@ Block Data (Obsolescent)
     (whitespace)
     (end_block_data_statement
       (whitespace)
-      (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement)))
   (whitespace)
   (block_data
     (block_data_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (whitespace)
@@ -2663,20 +2730,25 @@ Block Data (Obsolescent)
     (whitespace)
     (end_block_data_statement
       (whitespace)
-      (name)
+      (whitespace)
+      (whitespace)
+      (name
+        (identifier))
       (end_of_statement)))
   (whitespace)
   (block_data
     (block_data_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (whitespace)
@@ -2697,5 +2769,79 @@ Block Data (Obsolescent)
     (end_block_data_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
+      (end_of_statement)))
+  (whitespace)
+  (block_data
+    (block_data_statement
+      (whitespace)
+      (whitespace)
+      (name
+        (identifier))
+      (end_of_statement))
+    (whitespace)
+    (common_statement
+      (whitespace)
+      (variable_group
+        (name
+          (identifier))
+        (whitespace)
+        (identifier)
+        (whitespace)
+        (identifier)
+        (whitespace)
+        (identifier)))
+    (end_of_statement)
+    (whitespace)
+    (data_statement
+      (whitespace)
+      (data_set
+        (identifier)
+        (whitespace)
+        (data_value
+          (number_literal))))
+    (end_of_statement)
+    (whitespace)
+    (end_block_data_statement
+      (whitespace)
+      (name
+        (identifier))
+      (end_of_statement)))
+  (whitespace)
+  (block_data
+    (block_data_statement
+      (whitespace)
+      (whitespace)
+      (name
+        (identifier))
+      (end_of_statement))
+    (whitespace)
+    (common_statement
+      (whitespace)
+      (variable_group
+        (name
+          (identifier))
+        (whitespace)
+        (identifier)
+        (whitespace)
+        (identifier)
+        (whitespace)
+        (identifier)))
+    (end_of_statement)
+    (whitespace)
+    (data_statement
+      (whitespace)
+      (data_set
+        (identifier)
+        (whitespace)
+        (data_value
+          (number_literal))))
+    (end_of_statement)
+    (whitespace)
+    (end_block_data_statement
+      (whitespace)
+      (whitespace)
+      (name
+        (identifier))
       (end_of_statement))))

--- a/test/corpus/cudafortran.txt
+++ b/test/corpus/cudafortran.txt
@@ -14,7 +14,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -42,7 +43,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -67,7 +69,8 @@ end function
           (number_literal)))
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (comment)
@@ -75,7 +78,8 @@ end function
     (use_statement
       (whitespace)
       (module_name
-        (name)))
+        (name
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (assignment_statement
@@ -109,7 +113,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (subroutine_call

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -37,7 +37,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -272,7 +273,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -390,7 +392,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -427,7 +430,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -544,7 +548,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -677,7 +682,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (pointer_association_statement
@@ -700,7 +706,8 @@ END PROGRAM
     (pointer_association_statement
       (derived_type_member_expression
         (identifier)
-        (type_member))
+        (type_member
+          (identifier)))
       (whitespace)
       (whitespace)
       (identifier))
@@ -725,13 +732,15 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
       (derived_type_member_expression
         (identifier)
-        (type_member))
+        (type_member
+          (identifier)))
       (whitespace)
       (whitespace)
       (identifier))
@@ -743,14 +752,16 @@ END PROGRAM
       (whitespace)
       (derived_type_member_expression
         (identifier)
-        (type_member)))
+        (type_member
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (assignment_statement
       (call_expression
         (derived_type_member_expression
           (identifier)
-          (type_member))
+          (type_member
+            (identifier)))
         (argument_list
           (extent_specifier
             (number_literal)
@@ -786,7 +797,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -945,7 +957,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -1205,7 +1218,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -1284,7 +1298,8 @@ END PROGRAM
     (assignment_statement
       left: (derived_type_member_expression
         (identifier)
-        (type_member))
+        (type_member
+          (identifier)))
       (whitespace)
       (whitespace)
       right: (call_expression
@@ -1339,14 +1354,16 @@ end program use_type_bound_procedures
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (subroutine_call
       (whitespace)
       (derived_type_member_expression
         (identifier)
-        (type_member))
+        (type_member
+          (identifier)))
       (argument_list))
     (end_of_statement)
     (whitespace)
@@ -1358,14 +1375,17 @@ end program use_type_bound_procedures
             (identifier)
             (argument_list
               (identifier)))
-          (type_member))
-        (type_member))
+          (type_member
+            (identifier)))
+        (type_member
+          (identifier)))
       (argument_list))
     (end_of_statement)
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1388,7 +1408,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (write_statement
@@ -1447,7 +1468,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (print_statement
@@ -1460,7 +1482,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1485,7 +1508,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -1540,8 +1564,7 @@ end program
           (ERROR
             (ERROR
               (number_literal))
-            (user_defined_operator_name)
-            (number_literal))
+            (user_defined_operator_name))
           (whitespace)
           (whitespace)
           (number_literal))))
@@ -1574,7 +1597,8 @@ end program array_constructors
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (implicit_statement
@@ -1739,7 +1763,8 @@ end program array_constructors
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1774,7 +1799,8 @@ end subroutine foo
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -1891,7 +1917,8 @@ end subroutine foo
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -1964,7 +1991,8 @@ end subroutine foo
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1984,7 +2012,8 @@ end subroutine test
   (subroutine
     (subroutine_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       parameters: (parameters
         (identifier)
         (whitespace)
@@ -2048,7 +2077,8 @@ end subroutine test
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -2071,7 +2101,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -2188,7 +2219,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -2206,7 +2238,8 @@ end
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -2257,7 +2290,8 @@ end
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration

--- a/test/corpus/floating.txt
+++ b/test/corpus/floating.txt
@@ -165,7 +165,8 @@ common /blk/ a, b
   (common_statement
     (whitespace)
     (variable_group
-      (name)
+      (name
+        (identifier))
       (whitespace)
       (identifier)
       (whitespace)
@@ -187,7 +188,8 @@ end type t
     (derived_type_statement
       (whitespace)
       (whitespace)
-      (type_name)
+      (type_name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -199,7 +201,8 @@ end type t
     (end_type_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -236,7 +239,8 @@ end interface
     (subroutine
       (subroutine_statement
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (parameters
           (identifier))
         (end_of_statement))
@@ -251,7 +255,8 @@ end interface
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (end_interface_statement
       (whitespace)
@@ -269,7 +274,8 @@ use iso_fortran_env, only: int32
   (use_statement
     (whitespace)
     (module_name
-      (name))
+      (name
+        (identifier)))
     (included_items
       (whitespace)
       (whitespace)
@@ -462,7 +468,8 @@ a = 1
     (derived_type_statement
       (whitespace)
       (whitespace)
-      (type_name)
+      (type_name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -474,7 +481,8 @@ a = 1
     (end_type_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement)))
   (variable_declaration
     (intrinsic_type)
@@ -517,7 +525,8 @@ end
       (derived_type_statement
         (whitespace)
         (whitespace)
-        (type_name)
+        (type_name
+          (identifier))
         (end_of_statement))
       (end_type_statement
         (whitespace)
@@ -532,7 +541,8 @@ end
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))
         (end_subroutine_statement
           (end_of_statement))))))
@@ -636,7 +646,8 @@ end interface
     (module
       (module_statement
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement))
       (internal_procedures
         (contains_statement)
@@ -645,18 +656,21 @@ end interface
         (subroutine
           (subroutine_statement
             (whitespace)
-            (name)
+            (name
+              (identifier))
             (end_of_statement))
           (whitespace)
           (end_subroutine_statement
             (whitespace)
             (whitespace)
-            (name)
+            (name
+              (identifier))
             (end_of_statement))))
       (end_module_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (preproc_else
       (interface
@@ -666,13 +680,15 @@ end interface
         (subroutine
           (subroutine_statement
             (whitespace)
-            (name)
+            (name
+              (identifier))
             (end_of_statement))
           (whitespace)
           (end_subroutine_statement
             (whitespace)
             (whitespace)
-            (name)
+            (name
+              (identifier))
             (end_of_statement)))
         (end_interface_statement
           (whitespace)

--- a/test/corpus/line_continuations.txt
+++ b/test/corpus/line_continuations.txt
@@ -14,7 +14,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (write_statement
@@ -65,7 +66,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (write_statement
@@ -111,7 +113,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -129,7 +132,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -151,7 +155,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (internal_procedures
       (contains_statement)
@@ -160,7 +165,8 @@ end program test
       (function
         (function_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (whitespace)
             (whitespace)
@@ -183,12 +189,14 @@ end program test
         (end_function_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))))
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -207,7 +215,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (write_statement
@@ -247,7 +256,8 @@ end program ! comment
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -277,7 +287,8 @@ end program ! comment
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (whitespace)
           (end_of_statement))
         (comment)
@@ -285,7 +296,8 @@ end program ! comment
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (whitespace)
           (end_of_statement))))
     (comment)
@@ -318,7 +330,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (print_statement
@@ -392,7 +405,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (statement_label)
     (whitespace)
@@ -438,7 +452,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -467,7 +482,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -484,7 +500,8 @@ end program main
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (comment)
@@ -500,5 +517,6 @@ end program main
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))

--- a/test/corpus/preprocessor.txt
+++ b/test/corpus/preprocessor.txt
@@ -169,12 +169,14 @@ end subroutine foo4
     content: (subroutine
       (subroutine_statement
         (whitespace)
-        name: (name)
+        name: (name
+          (identifier))
         (end_of_statement))
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement))))
   (preproc_ifdef
     (whitespace)
@@ -182,12 +184,14 @@ end subroutine foo4
     content: (subroutine
       (subroutine_statement
         (whitespace)
-        name: (name)
+        name: (name
+          (identifier))
         (end_of_statement))
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     content: (preproc_def
       (whitespace)
@@ -203,12 +207,14 @@ end subroutine foo4
         content: (subroutine
           (subroutine_statement
             (whitespace)
-            name: (name)
+            name: (name
+              (identifier))
             (end_of_statement))
           (end_subroutine_statement
             (whitespace)
             (whitespace)
-            (name)
+            (name
+              (identifier))
             (end_of_statement)))
         content: (preproc_def
           (whitespace)
@@ -223,12 +229,14 @@ end subroutine foo4
     content: (subroutine
       (subroutine_statement
         (whitespace)
-        name: (name)
+        name: (name
+          (identifier))
         (end_of_statement))
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (whitespace)
     (inline_preproc_comment)))
@@ -265,12 +273,14 @@ end subroutine foo5
     content: (subroutine
       (subroutine_statement
         (whitespace)
-        name: (name)
+        name: (name
+          (identifier))
         (end_of_statement))
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     alternative: (preproc_elifdef
       (whitespace)
@@ -278,12 +288,14 @@ end subroutine foo5
       content: (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))))
   (preproc_ifdef
     (whitespace)
@@ -291,12 +303,14 @@ end subroutine foo5
     content: (subroutine
       (subroutine_statement
         (whitespace)
-        name: (name)
+        name: (name
+          (identifier))
         (end_of_statement))
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     alternative: (preproc_elifdef
       (whitespace)
@@ -304,23 +318,27 @@ end subroutine foo5
       content: (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       alternative: (preproc_else
         content: (subroutine
           (subroutine_statement
             (whitespace)
-            name: (name)
+            name: (name
+              (identifier))
             (end_of_statement))
           (end_subroutine_statement
             (whitespace)
             (whitespace)
-            (name)
+            (name
+              (identifier))
             (end_of_statement)))))))
 
 ================================================================================
@@ -355,12 +373,14 @@ end subroutine e
     content: (subroutine
       (subroutine_statement
         (whitespace)
-        name: (name)
+        name: (name
+          (identifier))
         (end_of_statement))
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     alternative: (preproc_elif
       (whitespace)
@@ -369,12 +389,14 @@ end subroutine e
       content: (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))))
   (preproc_if
     (whitespace)
@@ -384,12 +406,14 @@ end subroutine e
     content: (subroutine
       (subroutine_statement
         (whitespace)
-        name: (name)
+        name: (name
+          (identifier))
         (end_of_statement))
       (end_subroutine_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     alternative: (preproc_elifdef
       (whitespace)
@@ -397,23 +421,27 @@ end subroutine e
       content: (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       alternative: (preproc_else
         content: (subroutine
           (subroutine_statement
             (whitespace)
-            name: (name)
+            name: (name
+              (identifier))
             (end_of_statement))
           (end_subroutine_statement
             (whitespace)
             (whitespace)
-            (name)
+            (name
+              (identifier))
             (end_of_statement)))))))
 
 ================================================================================
@@ -544,7 +572,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (preproc_call
       (preproc_directive)
@@ -560,7 +589,8 @@ end program test
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))
         (preproc_call
           (preproc_directive)
@@ -580,7 +610,8 @@ end program test
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (preproc_call
         (preproc_directive)
@@ -589,7 +620,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -610,13 +642,15 @@ end program
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (included_items
         (whitespace)
         (whitespace)
@@ -635,7 +669,8 @@ end program
       content: (use_statement
         (whitespace)
         (module_name
-          (name)))
+          (name
+            (identifier))))
       content: (end_of_statement))
     (end_program_statement
       (whitespace)
@@ -665,13 +700,15 @@ end module foo
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (derived_type_definition
       (derived_type_statement
         (whitespace)
-        (type_name)
+        (type_name
+          (identifier))
         (end_of_statement))
       (preproc_include
         (whitespace)
@@ -702,17 +739,20 @@ end module foo
             (whitespace)
             (whitespace)
             (method_name
-              (name)))))
+              (name
+                (identifier))))))
       (whitespace)
       (end_type_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (end_module_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -741,7 +781,8 @@ end module foo
   (module
     (module_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (internal_procedures
       (contains_statement)
@@ -750,13 +791,15 @@ end module foo
       (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (whitespace)
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (preproc_ifdef
         (whitespace)
@@ -765,30 +808,35 @@ end module foo
         content: (subroutine
           (subroutine_statement
             (whitespace)
-            name: (name)
+            name: (name
+              (identifier))
             (end_of_statement))
           (whitespace)
           (end_subroutine_statement
             (whitespace)
             (whitespace)
-            (name)
+            (name
+              (identifier))
             (end_of_statement))))
       (whitespace)
       (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (whitespace)
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))))
     (end_module_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -819,7 +867,8 @@ end module foo
   (module
     (module_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (internal_procedures
       (contains_statement)
@@ -828,7 +877,8 @@ end module foo
       (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (whitespace)
         (variable_declaration
@@ -873,24 +923,28 @@ end module foo
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (whitespace)
       (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (whitespace)
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))))
     (end_module_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -920,7 +974,8 @@ end module foo
   (module
     (module_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (internal_procedures
       (contains_statement)
@@ -929,7 +984,8 @@ end module foo
       (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (whitespace)
         (variable_declaration
@@ -962,24 +1018,28 @@ end module foo
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (whitespace)
       (subroutine
         (subroutine_statement
           (whitespace)
-          name: (name)
+          name: (name
+            (identifier))
           (end_of_statement))
         (whitespace)
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))))
     (end_module_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1015,7 +1075,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (implicit_statement
@@ -1134,13 +1195,15 @@ end module
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (interface
       (interface_statement
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (procedure_statement
@@ -1148,7 +1211,8 @@ end module
           (whitespace))
         (whitespace)
         (method_name
-          (name)))
+          (name
+            (identifier))))
       (preproc_ifdef
         (whitespace)
         (identifier)
@@ -1158,7 +1222,8 @@ end module
             (whitespace))
           (whitespace)
           (method_name
-            (name))))
+            (name
+              (identifier)))))
       (whitespace)
       (end_interface_statement
         (whitespace)
@@ -1198,7 +1263,8 @@ Preprocessor in specification part
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (implicit_statement
@@ -1307,7 +1373,8 @@ Preprocessor in specification part
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1343,7 +1410,8 @@ Baz */
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration

--- a/test/corpus/regressions.txt
+++ b/test/corpus/regressions.txt
@@ -24,13 +24,15 @@ end program example_padl
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (included_items
         (whitespace)
         (whitespace)
@@ -45,7 +47,8 @@ end program example_padl
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (included_items
         (whitespace)
         (whitespace)
@@ -59,7 +62,8 @@ end program example_padl
     (whitespace)
     (variable_declaration
       (derived_type
-        (type_name))
+        (type_name
+          (identifier)))
       (whitespace)
       (whitespace)
       (identifier))
@@ -109,7 +113,8 @@ end program example_padl
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================
@@ -132,12 +137,14 @@ end program foo
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (if_statement
       (block_if_statement
-        (block_label_start_expression)
+        (block_label_start_expression
+          (identifier))
         (whitespace)
         (whitespace)
         (parenthesized_expression
@@ -153,7 +160,8 @@ end program foo
         (whitespace)
         (else_clause
           (whitespace)
-          (block_label)
+          (block_label
+            (identifier))
           (end_of_statement)
           (whitespace)
           (subroutine_call
@@ -164,12 +172,14 @@ end program foo
         (whitespace)
         (end_if_statement
           (whitespace)
-          (block_label))))
+          (block_label
+            (identifier)))))
     (end_of_statement)
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================
@@ -191,7 +201,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (if_statement
@@ -233,7 +244,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -252,7 +264,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -269,7 +282,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (assignment_statement
@@ -325,7 +339,8 @@ Multiple array assignments
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier)
         (whitespace)
@@ -454,5 +469,6 @@ Multiple array assignments
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -35,7 +35,8 @@ end subroutine foo
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (include_statement
@@ -84,7 +85,8 @@ end subroutine foo
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))
         (whitespace)
         (include_statement
@@ -95,7 +97,8 @@ end subroutine foo
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))))
     (end_program_statement
       (whitespace)
@@ -104,17 +107,20 @@ end subroutine foo
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (end_module_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement)))
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (include_statement
@@ -145,7 +151,8 @@ end subroutine foo
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -171,19 +178,22 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (use_statement
       (whitespace)
       (module_name
-        (name)))
+        (name
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (included_items
         (whitespace)
         (whitespace)
@@ -196,7 +206,8 @@ END PROGRAM
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (included_items
         (whitespace)
         (identifier)))
@@ -207,7 +218,8 @@ END PROGRAM
       (whitespace)
       (whitespace)
       (module_name
-        (name)))
+        (name
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (use_statement
@@ -215,18 +227,21 @@ END PROGRAM
       (whitespace)
       (whitespace)
       (module_name
-        (name)))
+        (name
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (included_items
         (whitespace)
         (whitespace)
         (use_alias
-          (local_name)
+          (local_name
+            (identifier))
           (whitespace)
           (whitespace)
           (identifier))))
@@ -236,10 +251,12 @@ END PROGRAM
       (whitespace)
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (whitespace)
       (use_alias
-        (local_name)
+        (local_name
+          (identifier))
         (whitespace)
         (whitespace)
         (identifier)))
@@ -249,13 +266,15 @@ END PROGRAM
       (whitespace)
       (whitespace)
       (module_name
-        (name)))
+        (name
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (included_items
         (whitespace)))
     (end_of_statement)
@@ -263,10 +282,12 @@ END PROGRAM
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (whitespace)
       (use_alias
-        (local_name)
+        (local_name
+          (identifier))
         (whitespace)
         (whitespace)
         (identifier)))
@@ -292,7 +313,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (implicit_statement
@@ -343,12 +365,14 @@ END PROGRAM
     (implicit_statement
       (whitespace)
       (derived_type
-        (type_name))
+        (type_name
+          (identifier)))
       (implicit_range
         (implicit_range_letter))
       (whitespace)
       (derived_type
-        (type_name))
+        (type_name
+          (identifier)))
       (implicit_range
         (implicit_range_letter)))
     (end_of_statement)
@@ -371,7 +395,8 @@ END MODULE
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (save_statement)
@@ -407,7 +432,8 @@ END MODULE
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (private_statement)
@@ -445,7 +471,8 @@ END MODULE
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (public_statement)
@@ -495,7 +522,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -728,12 +756,14 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
       (derived_type
-        (type_name))
+        (type_name
+          (identifier)))
       (whitespace)
       (whitespace)
       (identifier))
@@ -772,7 +802,8 @@ END PROGRAM
     (whitespace)
     (variable_declaration
       (derived_type
-        (type_name)
+        (type_name
+          (identifier))
         (kind
           (number_literal)
           (whitespace)
@@ -784,7 +815,8 @@ END PROGRAM
     (whitespace)
     (variable_declaration
       (derived_type
-        (type_name))
+        (type_name
+          (identifier)))
       (whitespace)
       (type_qualifier)
       (whitespace)
@@ -835,7 +867,8 @@ end module foo
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (internal_procedures
       (contains_statement)
@@ -843,7 +876,8 @@ end module foo
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier)
             (whitespace)
@@ -852,7 +886,8 @@ end module foo
         (whitespace)
         (variable_declaration
           (derived_type
-            (type_name))
+            (type_name
+              (identifier)))
           (whitespace)
           (type_qualifier)
           (whitespace)
@@ -872,12 +907,14 @@ end module foo
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier)
             (whitespace)
@@ -886,7 +923,8 @@ end module foo
         (whitespace)
         (variable_declaration
           (derived_type
-            (type_name))
+            (type_name
+              (identifier)))
           (whitespace)
           (type_qualifier)
           (whitespace)
@@ -908,12 +946,14 @@ end module foo
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (subroutine
         (subroutine_statement
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier)
             (whitespace)
@@ -947,12 +987,14 @@ end module foo
         (end_subroutine_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement))))
     (end_module_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -975,7 +1017,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_modification
@@ -1064,7 +1107,8 @@ END PROGRAM
       (whitespace)
       (identifier)
       (whitespace)
-      (common_block)
+      (common_block
+        (identifier))
       (whitespace)
       (identifier))
     (end_of_statement)
@@ -1117,7 +1161,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (do_loop
@@ -1195,7 +1240,8 @@ END PROGRAM
     (end_of_statement)
     (whitespace)
     (do_loop
-      (block_label_start_expression)
+      (block_label_start_expression
+        (identifier))
       (whitespace)
       (do_statement
         (whitespace)
@@ -1242,7 +1288,8 @@ END PROGRAM
       (end_do_loop_statement
         (whitespace)
         (whitespace)
-        (block_label)))
+        (block_label
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (do_loop
@@ -1319,7 +1366,8 @@ END PROGRAM TEST
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -1452,7 +1500,8 @@ END PROGRAM TEST
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1476,7 +1525,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (do_label_statement
@@ -1555,7 +1605,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -1573,7 +1624,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (keyword_statement
@@ -1641,7 +1693,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (if_statement
@@ -1770,7 +1823,8 @@ END PROGRAM
     (whitespace)
     (if_statement
       (block_if_statement
-        (block_label_start_expression)
+        (block_label_start_expression
+          (identifier))
         (whitespace)
         (whitespace)
         (parenthesized_expression
@@ -1800,7 +1854,8 @@ END PROGRAM
               (number_literal)))
           (whitespace)
           (whitespace)
-          (block_label)
+          (block_label
+            (identifier))
           (end_of_statement)
           (whitespace)
           (assignment_statement
@@ -1846,7 +1901,8 @@ END PROGRAM
         (whitespace)
         (else_clause
           (whitespace)
-          (block_label)
+          (block_label
+            (identifier))
           (end_of_statement)
           (whitespace)
           (assignment_statement
@@ -1859,7 +1915,8 @@ END PROGRAM
         (end_if_statement
           (whitespace)
           (whitespace)
-          (block_label))))
+          (block_label
+            (identifier)))))
     (end_of_statement)
     (end_program_statement
       (whitespace)
@@ -1898,7 +1955,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (where_statement
       (inline_where_statement
@@ -1983,7 +2041,8 @@ end program
     (end_of_statement)
     (where_statement
       (block_where_statement
-        (block_label_start_expression)
+        (block_label_start_expression
+          (identifier))
         (whitespace)
         (parenthesized_expression
           (relational_expression
@@ -2012,7 +2071,8 @@ end program
               (whitespace)
               (number_literal)))
           (whitespace)
-          (block_label)
+          (block_label
+            (identifier))
           (end_of_statement)
           (whitespace)
           (assignment_statement
@@ -2027,7 +2087,8 @@ end program
           (end_of_statement))
         (elsewhere_clause
           (whitespace)
-          (block_label)
+          (block_label
+            (identifier))
           (end_of_statement)
           (whitespace)
           (assignment_statement
@@ -2038,7 +2099,8 @@ end program
           (end_of_statement))
         (end_where_statement
           (whitespace)
-          (block_label))))
+          (block_label
+            (identifier)))))
     (end_of_statement)
     (end_program_statement
       (whitespace)
@@ -2072,7 +2134,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (forall_statement
       (inline_forall_statement
@@ -2134,7 +2197,8 @@ END PROGRAM
               (identifier)
               (argument_list
                 (identifier)))
-            (type_member))
+            (type_member
+              (identifier)))
           (whitespace)
           (whitespace)
           (call_expression
@@ -2358,11 +2422,13 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (select_case_statement
-      (block_label_start_expression)
+      (block_label_start_expression
+        (identifier))
       (whitespace)
       (whitespace)
       (whitespace)
@@ -2378,7 +2444,8 @@ END PROGRAM
             (unary_expression
               (number_literal))))
         (whitespace)
-        (block_label)
+        (block_label
+          (identifier))
         (end_of_statement)
         (whitespace)
         (assignment_statement
@@ -2394,7 +2461,8 @@ END PROGRAM
         (case_value_range_list
           (number_literal))
         (whitespace)
-        (block_label)
+        (block_label
+          (identifier))
         (end_of_statement)
         (whitespace)
         (assignment_statement
@@ -2411,7 +2479,8 @@ END PROGRAM
             (number_literal)
             (whitespace)))
         (whitespace)
-        (block_label)
+        (block_label
+          (identifier))
         (end_of_statement)
         (whitespace)
         (assignment_statement
@@ -2424,7 +2493,8 @@ END PROGRAM
       (end_select_statement
         (whitespace)
         (whitespace)
-        (block_label)))
+        (block_label
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (select_case_statement
@@ -2551,7 +2621,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (statement_label)
     (whitespace)
@@ -2666,7 +2737,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (read_statement
@@ -2778,7 +2850,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (print_statement
@@ -2844,7 +2917,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -3008,7 +3082,8 @@ end function test4
   (function
     (function_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (import_statement
@@ -3021,12 +3096,14 @@ end function test4
     (end_function_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement)))
   (function
     (function_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (import_statement
@@ -3038,12 +3115,14 @@ end function test4
     (end_function_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement)))
   (function
     (function_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier))
       (end_of_statement))
@@ -3053,7 +3132,8 @@ end function test4
     (whitespace)
     (variable_declaration
       (derived_type
-        (type_name))
+        (type_name
+          (identifier)))
       (whitespace)
       (type_qualifier)
       (whitespace)
@@ -3063,12 +3143,14 @@ end function test4
     (end_function_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement)))
   (function
     (function_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (import_statement
@@ -3080,7 +3162,8 @@ end function test4
     (end_function_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -3099,20 +3182,23 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (whitespace)
         (identifier))
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)))
     (end_of_statement)
@@ -3120,7 +3206,8 @@ END PROGRAM
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (sized_declarator
           (identifier)
@@ -3159,7 +3246,8 @@ END PROGRAM
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -3183,13 +3271,15 @@ END PROGRAM
     (namelist_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (identifier))
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)
         (identifier)))
@@ -3218,7 +3308,8 @@ END PROGRAM test
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (enum
@@ -3270,7 +3361,8 @@ END PROGRAM test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -3302,7 +3394,8 @@ end subroutine print_decorated_numbers
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier))
       (end_of_statement))
@@ -3417,7 +3510,8 @@ end subroutine print_decorated_numbers
           (output_item_list
             (derived_type_member_expression
               (identifier)
-              (type_member))))
+              (type_member
+                (identifier)))))
         (end_of_statement))
       (whitespace)
       (type_statement
@@ -3439,7 +3533,8 @@ end subroutine print_decorated_numbers
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -3465,7 +3560,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -3529,7 +3625,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -3557,7 +3654,8 @@ end subroutine assumed_rank
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier))
       (end_of_statement))
@@ -3645,7 +3743,8 @@ end subroutine assumed_rank
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -3666,7 +3765,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (associate_statement
@@ -3684,7 +3784,8 @@ end program
       (end_of_statement)
       (whitespace)
       (associate_statement
-        (block_label_start_expression)
+        (block_label_start_expression
+          (identifier))
         (association
           (identifier)
           (whitespace)
@@ -3692,7 +3793,8 @@ end program
           (call_expression
             (derived_type_member_expression
               (identifier)
-              (type_member))
+              (type_member
+                (identifier)))
             (argument_list)))
         (end_of_statement)
         (whitespace)
@@ -3710,7 +3812,8 @@ end program
         (end_associate_statement
           (whitespace)
           (whitespace)
-          (block_label)))
+          (block_label
+            (identifier))))
       (end_of_statement)
       (whitespace)
       (end_associate_statement
@@ -3749,7 +3852,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (interface
@@ -3764,7 +3868,8 @@ end program
           (intrinsic_type)
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier))
           (end_of_statement))
@@ -3781,7 +3886,8 @@ end program
         (end_function_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (whitespace)
       (end_interface_statement
@@ -3800,7 +3906,8 @@ end program
           (intrinsic_type)
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (parameters
             (identifier)
             (whitespace)
@@ -3821,7 +3928,8 @@ end program
         (end_function_statement
           (whitespace)
           (whitespace)
-          (name)
+          (name
+            (identifier))
           (end_of_statement)))
       (whitespace)
       (end_interface_statement
@@ -3900,13 +4008,15 @@ end module
   (module
     (module_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (use_statement
       (whitespace)
       (module_name
-        (name))
+        (name
+          (identifier)))
       (included_items
         (whitespace)
         (whitespace)
@@ -3945,7 +4055,8 @@ end module
         (whitespace)
         (whitespace)
         (method_name
-          (name)))
+          (name
+            (identifier))))
       (whitespace)
       (end_interface_statement
         (whitespace)
@@ -3962,7 +4073,8 @@ end module
           (whitespace))
         (whitespace)
         (method_name
-          (name)))
+          (name
+            (identifier))))
       (whitespace)
       (end_interface_statement
         (whitespace)
@@ -3973,7 +4085,8 @@ end module
     (derived_type_definition
       (derived_type_statement
         (whitespace)
-        (type_name)
+        (type_name
+          (identifier))
         (end_of_statement))
       (whitespace)
       (derived_type_procedures
@@ -3993,7 +4106,8 @@ end module
             (whitespace)
             (whitespace)
             (method_name
-              (name))))
+              (name
+                (identifier)))))
         (whitespace)
         (comment)
         (whitespace)
@@ -4009,12 +4123,14 @@ end module
             (whitespace)
             (whitespace)
             (method_name
-              (name)))))
+              (name
+                (identifier))))))
       (whitespace)
       (end_type_statement
         (whitespace)
         (whitespace)
-        (name)
+        (name
+          (identifier))
         (end_of_statement)))
     (end_module_statement
       (whitespace)
@@ -4052,7 +4168,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (data_statement
@@ -4108,7 +4225,8 @@ end program test
       (data_set
         (derived_type_member_expression
           (identifier)
-          (type_member))
+          (type_member
+            (identifier)))
         (whitespace)
         (data_value
           (whitespace)
@@ -4260,7 +4378,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -4291,7 +4410,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (file_position_statement
@@ -4321,7 +4441,8 @@ end program
       (unit_identifier
         (derived_type_member_expression
           (identifier)
-          (type_member)))
+          (type_member
+            (identifier))))
       (whitespace)
       (keyword_argument
         (identifier)
@@ -4390,7 +4511,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (inquire_statement
@@ -4446,7 +4568,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -4475,7 +4598,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (allocate_statement
@@ -4520,8 +4644,10 @@ end program test
         (derived_type_member_expression
           (derived_type_member_expression
             (identifier)
-            (type_member))
-          (type_member))
+            (type_member
+              (identifier)))
+          (type_member
+            (identifier)))
         (size
           (number_literal)
           (whitespace)
@@ -4539,7 +4665,8 @@ end program test
             (identifier)
             (argument_list
               (identifier)))
-          (type_member))
+          (type_member
+            (identifier)))
         (size
           (identifier)
           (whitespace)
@@ -4559,7 +4686,8 @@ end program test
     (deallocate_statement
       (derived_type_member_expression
         (identifier)
-        (type_member)))
+        (type_member
+          (identifier))))
     (end_of_statement)
     (whitespace)
     (deallocate_statement
@@ -4587,12 +4715,14 @@ end program test
     (nullify_statement
       (derived_type_member_expression
         (identifier)
-        (type_member)))
+        (type_member
+          (identifier))))
     (end_of_statement)
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -4646,7 +4776,8 @@ Statement Functions (Obsolescent)
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (whitespace)
         (identifier)
@@ -4741,7 +4872,8 @@ Statement Functions (Obsolescent)
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -4773,7 +4905,8 @@ Entry statement (Obsolescent)
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier)
         (whitespace)
@@ -4803,7 +4936,8 @@ Entry statement (Obsolescent)
     (whitespace)
     (entry_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier)
         (whitespace)
@@ -4817,7 +4951,8 @@ Entry statement (Obsolescent)
     (whitespace)
     (entry_statement
       (whitespace)
-      (name))
+      (name
+        (identifier)))
     (end_of_statement)
     (whitespace)
     (keyword_statement)
@@ -4829,14 +4964,16 @@ Entry statement (Obsolescent)
   (subroutine
     (subroutine_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier))
       (end_of_statement))
     (whitespace)
     (entry_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (parameters
         (identifier)))
     (end_of_statement)
@@ -4850,7 +4987,8 @@ Entry statement (Obsolescent)
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -4870,7 +5008,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -4936,7 +5075,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -4957,7 +5097,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (print_statement
@@ -5037,7 +5178,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -5061,7 +5203,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (coarray_statement
@@ -5133,7 +5276,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -5156,7 +5300,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (coarray_statement
@@ -5182,7 +5327,8 @@ end program test
       (end_of_statement)
       (whitespace)
       (coarray_team_statement
-        (block_label_start_expression)
+        (block_label_start_expression
+          (identifier))
         (whitespace)
         (whitespace)
         (argument_list
@@ -5215,7 +5361,8 @@ end program test
         (end_coarray_team_statement
           (whitespace)
           (whitespace)
-          (block_label)))
+          (block_label
+            (identifier))))
       (end_of_statement)
       (whitespace)
       (end_coarray_team_statement
@@ -5224,7 +5371,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -5243,7 +5391,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (coarray_critical_statement
@@ -5265,7 +5414,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -5284,7 +5434,8 @@ end program test;
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (whitespace)
@@ -5310,7 +5461,8 @@ end program test;
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -5327,7 +5479,8 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -5345,7 +5498,8 @@ end program test
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -5365,7 +5519,8 @@ end subroutine test
   (subroutine
     (subroutine_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       parameters: (parameters
         (identifier)
         (whitespace)
@@ -5403,7 +5558,8 @@ end subroutine test
     (whitespace)
     (variable_declaration
       type: (derived_type
-        name: (type_name))
+        name: (type_name
+          (identifier)))
       (whitespace)
       (whitespace)
       declarator: (identifier))
@@ -5413,7 +5569,8 @@ end subroutine test
       type: (declared_type
         name: (derived_type_member_expression
           (identifier)
-          (type_member)))
+          (type_member
+            (identifier))))
       (whitespace)
       (whitespace)
       declarator: (identifier))
@@ -5421,7 +5578,8 @@ end subroutine test
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -5477,7 +5635,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (keyword_statement
@@ -5517,7 +5676,8 @@ end subroutine pointer_name_clash
   (subroutine
     (subroutine_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (whitespace)
       parameters: (parameters
         (whitespace)
@@ -5612,12 +5772,14 @@ end subroutine pointer_name_clash
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement)))
   (subroutine
     (subroutine_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (variable_declaration
@@ -5645,7 +5807,8 @@ end subroutine pointer_name_clash
     (end_subroutine_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))
 
 ================================================================================
@@ -5665,7 +5828,8 @@ end program
   (program
     (program_statement
       (whitespace)
-      name: (name)
+      name: (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (implicit_statement
@@ -5733,13 +5897,15 @@ end program test
   (program
     (program_statement
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))
     (whitespace)
     (common_statement
       (whitespace)
       (variable_group
-        (name)
+        (name
+          (identifier))
         (whitespace)
         (identifier)))
     (end_of_statement)
@@ -5756,10 +5922,12 @@ end program test
         (identifier))
       (whitespace)
       (whitespace)
-      (common_block))
+      (common_block
+        (identifier)))
     (end_of_statement)
     (end_program_statement
       (whitespace)
       (whitespace)
-      (name)
+      (name
+        (identifier))
       (end_of_statement))))


### PR DESCRIPTION
As you might be aware, I can't test this in this repo because it involves setting an env var to communicate with the external scanner.

This substitutes everywhere an `$.identifier` was with a new hidden rule that admits a `$.macro_identifier` as well. This fixes a parsing ambiguity when parsing this code:
```
subroutine parse_dict()
  allocate(GridEntity :: new_entity)
end subroutine parse_dict
```
When setting `GridEntity` as a macro identifier, the parser would first assume that it is an allocate statement without the optional type part, and that `GridEntity` is the name of the allocation place, and then end in ERROR due to the unexpected `::` part after.

It also hopefully ends other possible ambiguities that were not discovered yet